### PR TITLE
Add initial evidence event schema

### DIFF
--- a/docs/en/14-evidence-event-schema.md
+++ b/docs/en/14-evidence-event-schema.md
@@ -1,0 +1,199 @@
+# 14. Evidence Event Schema
+
+## Status
+
+This document defines the initial draft of the **AAEF Agentic Action Evidence Event Schema** for public review.
+
+Schema file:
+
+- `schemas/agentic-action-evidence-event.schema.json`
+
+Examples:
+
+- `examples/agentic-action-evidence-event.minimal.json`
+- `examples/agentic-action-evidence-event.valid.json`
+
+This schema is intended for AAEF v0.2.0 discussion and review. It is not a certification format and does not guarantee compliance by itself.
+
+## Purpose
+
+AAEF focuses on action assurance for agentic AI systems.
+
+The evidence event schema provides a structured way to record high-impact agentic actions so that an organization can later answer:
+
+1. Who or what acted?
+2. On whose behalf did it act?
+3. What authority did it have?
+4. Was the action allowed at the point of execution?
+5. What evidence proves what happened?
+
+The schema is designed to support:
+
+- logging design,
+- audit review,
+- SIEM or evidence pipeline integration,
+- incident reconstruction,
+- control testing,
+- and future interoperability discussion.
+
+## Design Principles
+
+### 1. Evidence should be structured
+
+A log line such as `send_email success` is not enough for action assurance.
+
+For high-impact actions, evidence should include identity, principal, authority, requested action, authorization decision, result, and evidence metadata.
+
+### 2. Model output is not authority
+
+The schema records the requested action and the authorization decision separately.
+
+A model may propose an action, but the evidence event should show whether that action was authorized at the action boundary.
+
+### 3. Trusted and untrusted inputs should be distinguishable
+
+Agentic AI systems may process external emails, web pages, tickets, documents, tool results, retrieved content, or memory.
+
+The schema includes:
+
+- `trusted_inputs_used`
+- `untrusted_inputs_excluded`
+- `context.input_sources`
+- `untrusted_content_influenced_action`
+
+These fields help show whether untrusted content influenced a high-impact action or was excluded from authorization.
+
+### 4. Evidence should support privacy and minimization
+
+The schema allows references and digests rather than requiring raw sensitive content.
+
+Examples:
+
+- `argument_digest`
+- `content_digest`
+- `result_digest`
+- `evidence_location`
+- `privacy_notes`
+
+Implementations should avoid storing unnecessary sensitive data in evidence events.
+
+### 5. Evidence should support incident reconstruction
+
+The schema includes fields such as:
+
+- `correlation_id`
+- `trace_id`
+- `delegation_chain_id`
+- `parent_action_id`
+- `tool_result_reference`
+- `revocation_reference`
+- `incident_reference`
+
+These fields support reconstruction of action sequences, delegation chains, and response actions.
+
+## Required Top-Level Fields
+
+The initial schema requires:
+
+- `schema`
+- `schema_version`
+- `action_id`
+- `timestamp`
+- `agent`
+- `principal`
+- `delegation`
+- `requested_action`
+- `authorization`
+- `result`
+- `evidence`
+
+Optional sections include:
+
+- `approval`
+- `context`
+- `response`
+- `extensions`
+
+## Required Evidence Content
+
+The schema is aligned with AAEF-EVD-02.
+
+For high-impact actions, evidence should include at minimum:
+
+- agent identity,
+- agent instance,
+- principal,
+- requested action,
+- resource,
+- authority scope,
+- authorization decision,
+- timestamp,
+- and result.
+
+## Relationship to Existing Example
+
+AAEF v0.1.x included:
+
+- `examples/agentic-action-evidence-event.json`
+
+That example demonstrated the concept.
+
+This schema turns the evidence event into a structured draft format that can be validated and reviewed.
+
+## Validation
+
+The schema uses JSON Schema Draft 2020-12.
+
+Possible validation tools include:
+
+- `ajv`
+- Python `jsonschema`
+- IDE or editor JSON Schema support
+
+Example with `ajv`:
+
+```bash
+ajv validate -s schemas/agentic-action-evidence-event.schema.json -d examples/agentic-action-evidence-event.valid.json
+```
+
+Example with Python:
+
+```bash
+python -m jsonschema schemas/agentic-action-evidence-event.schema.json -i examples/agentic-action-evidence-event.valid.json
+```
+
+Validation confirms structural conformance only.
+
+It does not prove that:
+
+- the action was safe,
+- the authorization was correct,
+- the evidence is complete,
+- the implementation conforms to AAEF,
+- or the organization is compliant with any law or standard.
+
+## Open Questions for Review
+
+Feedback is welcome on:
+
+- Which fields should be required?
+- Should `delegation` be required for all high-impact actions, or should authority be represented separately?
+- How should privacy-preserving evidence be represented?
+- Should raw tool arguments ever be stored?
+- Should signatures or tamper-evidence be specified more strictly?
+- How should cross-agent evidence be represented?
+- How should long-running tasks and principal context degradation be represented?
+- Should denied actions and executed actions use the same schema?
+- Should the schema be split into action attempt, authorization decision, and execution result events?
+
+## Future Work
+
+Future versions may add:
+
+- Tool Invocation Evidence Profile
+- Cross-Agent Evidence Profile
+- Principal Context Degradation fields
+- High-Impact Action Taxonomy integration
+- JSON Schema validation workflow
+- example invalid events
+- schema versioning policy

--- a/examples/agentic-action-evidence-event.minimal.json
+++ b/examples/agentic-action-evidence-event.minimal.json
@@ -1,0 +1,50 @@
+{
+  "schema": "aaef.agentic_action_evidence_event",
+  "schema_version": "0.2.0-draft",
+  "action_id": "act_20260425_000001",
+  "timestamp": "2026-04-25T00:00:00Z",
+  "event_type": "agentic_action_denied",
+  "agent": {
+    "agent_id": "agent.support.assistant",
+    "agent_instance_id": "inst_01HZYXAMPLE"
+  },
+  "principal": {
+    "principal_type": "human_user",
+    "principal_id": "user_12345"
+  },
+  "delegation": {
+    "authority_scope": [
+      "ticket.read",
+      "ticket.comment.prepare"
+    ]
+  },
+  "requested_action": {
+    "action_type": "external_email.send",
+    "resource": "customer@example.com",
+    "purpose": "customer_support_followup",
+    "risk_level": "high",
+    "external_effect_expected": true
+  },
+  "authorization": {
+    "decision": "deny",
+    "policy_id": "policy.external_communication.v1",
+    "reason": "Agent authority scope does not include external_email.send",
+    "trusted_inputs_used": [
+      "policy",
+      "authority_scope",
+      "principal_context"
+    ],
+    "untrusted_inputs_excluded": [
+      "ticket_body"
+    ],
+    "revocation_state_checked": true
+  },
+  "result": {
+    "status": "denied",
+    "external_effect": false
+  },
+  "evidence": {
+    "retention_class": "high_impact_action",
+    "tamper_evidence": "signed_log_entry"
+  }
+}

--- a/examples/agentic-action-evidence-event.valid.json
+++ b/examples/agentic-action-evidence-event.valid.json
@@ -1,0 +1,132 @@
+{
+  "schema": "aaef.agentic_action_evidence_event",
+  "schema_version": "0.2.0-draft",
+  "action_id": "act_20260425_000001",
+  "timestamp": "2026-04-25T00:00:00Z",
+  "event_type": "agentic_action_executed",
+  "agent": {
+    "agent_id": "agent.procurement.assistant",
+    "agent_instance_id": "inst_01HZYXAMPLE",
+    "agent_product": "Example Procurement Agent",
+    "operator_id": "org.example",
+    "issuer_id": "issuer.example",
+    "runtime_environment": "prod/procurement/workflow"
+  },
+  "principal": {
+    "principal_type": "human_user",
+    "principal_id": "user_12345",
+    "principal_context": "procurement_request",
+    "principal_context_id": "req_20260425_000001"
+  },
+  "delegation": {
+    "delegation_chain_id": "del_chain_abc123",
+    "parent_action_id": "act_20260425_000000",
+    "authority_scope": [
+      "vendor.quote.request",
+      "purchase_order.prepare"
+    ],
+    "constraints": {
+      "max_amount": "1000.00",
+      "currency": "USD",
+      "expires_at": "2026-04-25T01:00:00Z",
+      "max_count": 1,
+      "max_delegation_depth": 1,
+      "redelegation_allowed": false,
+      "allowed_resources": [
+        "vendor_xyz"
+      ],
+      "allowed_purposes": [
+        "office_supplies_procurement"
+      ]
+    }
+  },
+  "requested_action": {
+    "action_type": "purchase_order.create",
+    "resource": "vendor_xyz",
+    "purpose": "office_supplies_procurement",
+    "risk_level": "high",
+    "high_impact_category": "HIA-FIN",
+    "tool_name": "procurement_api",
+    "tool_operation": "create_purchase_order",
+    "argument_digest": "sha256:example-argument-digest",
+    "external_effect_expected": true
+  },
+  "authorization": {
+    "decision": "requires_human_approval",
+    "policy_id": "policy.procurement.high_risk_actions.v1",
+    "reason": "purchase_order.create exceeds autonomous execution authority",
+    "decision_timestamp": "2026-04-25T00:01:00Z",
+    "trusted_inputs_used": [
+      "policy",
+      "authority_scope",
+      "principal_context",
+      "risk_classification"
+    ],
+    "untrusted_inputs_excluded": [
+      "retrieved_web_content",
+      "external_email_body"
+    ],
+    "revocation_state_checked": true
+  },
+  "approval": {
+    "approval_required": true,
+    "approval_id": "approval_98765",
+    "approver_id": "manager_456",
+    "approval_decision": "approved",
+    "approval_timestamp": "2026-04-25T00:05:00Z",
+    "approval_context_presented": [
+      "agent_id",
+      "principal_id",
+      "requested_action",
+      "resource",
+      "purpose",
+      "risk_level",
+      "authority_scope",
+      "expected_external_effect"
+    ]
+  },
+  "context": {
+    "input_sources": [
+      {
+        "source_type": "user_instruction",
+        "source_id": "req_20260425_000001",
+        "trust_level": "trusted",
+        "provenance": "internal_workflow",
+        "content_digest": "sha256:example-user-instruction-digest",
+        "materially_influenced_action": true
+      },
+      {
+        "source_type": "retrieved_web_content",
+        "source_id": "web_001",
+        "trust_level": "untrusted",
+        "provenance": "external_vendor_page",
+        "content_digest": "sha256:example-retrieved-content-digest",
+        "materially_influenced_action": false
+      }
+    ],
+    "untrusted_content_influenced_action": false,
+    "retrieved_or_remembered_content_material": false,
+    "correlation_id": "corr_abc123",
+    "trace_id": "trace_xyz789"
+  },
+  "result": {
+    "status": "allowed_after_approval",
+    "tool_invoked": "procurement_api.create_purchase_order",
+    "tool_result_reference": "po_000123",
+    "external_effect": true,
+    "result_digest": "sha256:example-result-digest"
+  },
+  "evidence": {
+    "evidence_id": "ev_20260425_000001",
+    "evidence_hash": "sha256:example-evidence-hash",
+    "retention_class": "high_impact_action",
+    "tamper_evidence": "signed_log_entry",
+    "evidence_location": "evidence-store://aaef/events/act_20260425_000001",
+    "privacy_notes": "Raw tool arguments are not stored; argument_digest is retained."
+  },
+  "response": {
+    "revocation_triggered": false,
+    "isolation_triggered": false,
+    "incident_reference": "none"
+  }
+}

--- a/schemas/agentic-action-evidence-event.schema.json
+++ b/schemas/agentic-action-evidence-event.schema.json
@@ -1,0 +1,576 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mkz0010/agentic-authority-evidence-framework/schemas/agentic-action-evidence-event.schema.json",
+  "title": "AAEF Agentic Action Evidence Event",
+  "description": "Reference JSON Schema for recording high-impact agentic AI actions under AAEF. This schema is intended for public review and implementation feedback.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "action_id",
+    "timestamp",
+    "agent",
+    "principal",
+    "delegation",
+    "requested_action",
+    "authorization",
+    "result",
+    "evidence"
+  ],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "aaef.agentic_action_evidence_event",
+      "description": "Stable schema name for AAEF agentic action evidence events."
+    },
+    "schema_version": {
+      "type": "string",
+      "description": "Schema version used by this event.",
+      "examples": [
+        "0.2.0-draft"
+      ]
+    },
+    "action_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for the attempted or completed agentic action."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the action was attempted, authorized, denied, or executed."
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "agentic_action_attempted",
+        "agentic_action_denied",
+        "agentic_action_allowed",
+        "agentic_action_executed",
+        "agentic_action_failed",
+        "agentic_action_revoked"
+      ],
+      "description": "Type of evidence event.",
+      "default": "agentic_action_executed"
+    },
+    "agent": {
+      "$ref": "#/$defs/agent"
+    },
+    "principal": {
+      "$ref": "#/$defs/principal"
+    },
+    "delegation": {
+      "$ref": "#/$defs/delegation"
+    },
+    "requested_action": {
+      "$ref": "#/$defs/requested_action"
+    },
+    "authorization": {
+      "$ref": "#/$defs/authorization"
+    },
+    "approval": {
+      "$ref": "#/$defs/approval"
+    },
+    "context": {
+      "$ref": "#/$defs/context"
+    },
+    "result": {
+      "$ref": "#/$defs/result"
+    },
+    "evidence": {
+      "$ref": "#/$defs/evidence"
+    },
+    "response": {
+      "$ref": "#/$defs/response"
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Implementation-specific extension fields. Extensions should not replace required AAEF fields.",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "agent_id",
+        "agent_instance_id"
+      ],
+      "properties": {
+        "agent_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier for the agent product, agent definition, or logical agent."
+        },
+        "agent_instance_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier for the specific agent instance, session, runtime, tenant, workflow, or execution context."
+        },
+        "agent_product": {
+          "type": "string",
+          "description": "Human-readable product, platform, or agent name."
+        },
+        "operator_id": {
+          "type": "string",
+          "description": "Organization or entity responsible for operating the agent."
+        },
+        "issuer_id": {
+          "type": "string",
+          "description": "Entity that issued the agent identity, credential, authority grant, or attestation."
+        },
+        "runtime_environment": {
+          "type": "string",
+          "description": "Runtime, environment, tenant, or deployment boundary where the agent operated."
+        }
+      }
+    },
+    "principal": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "principal_type",
+        "principal_id"
+      ],
+      "properties": {
+        "principal_type": {
+          "type": "string",
+          "enum": [
+            "human_user",
+            "organization",
+            "system",
+            "upstream_agent",
+            "service_account",
+            "unknown"
+          ],
+          "description": "Type of principal on whose behalf the agent acted."
+        },
+        "principal_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier for the principal."
+        },
+        "principal_context": {
+          "type": "string",
+          "description": "Context describing the principal's instruction, business process, workflow, or purpose."
+        },
+        "principal_context_id": {
+          "type": "string",
+          "description": "Reference ID for a structured principal context, workflow, ticket, request, or authority grant."
+        }
+      }
+    },
+    "delegation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "authority_scope"
+      ],
+      "properties": {
+        "delegation_chain_id": {
+          "type": "string",
+          "description": "Identifier for the delegation chain, if applicable."
+        },
+        "parent_action_id": {
+          "type": "string",
+          "description": "Identifier for the upstream action that created or influenced this action, if applicable."
+        },
+        "authority_scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Authority scope under which the action was attempted."
+        },
+        "constraints": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "max_amount": {
+              "type": [
+                "string",
+                "number"
+              ],
+              "description": "Maximum permitted amount, where applicable."
+            },
+            "currency": {
+              "type": "string",
+              "description": "Currency for amount constraints, where applicable."
+            },
+            "expires_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Expiration time for the authority or delegation."
+            },
+            "max_count": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum number of permitted uses."
+            },
+            "max_delegation_depth": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Maximum permitted downstream delegation depth."
+            },
+            "redelegation_allowed": {
+              "type": "boolean",
+              "description": "Whether downstream redelegation was allowed."
+            },
+            "allowed_resources": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Allowed resources or resource patterns."
+            },
+            "allowed_purposes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Allowed purposes or purpose categories."
+            }
+          }
+        }
+      }
+    },
+    "requested_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "action_type",
+        "resource",
+        "purpose",
+        "risk_level"
+      ],
+      "properties": {
+        "action_type": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Type of action requested or attempted."
+        },
+        "resource": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Target resource, system, account, dataset, file, tool, service, or external party."
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Declared purpose or business justification for the action."
+        },
+        "risk_level": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "critical",
+            "unknown"
+          ],
+          "description": "Risk classification of the requested action."
+        },
+        "high_impact_category": {
+          "type": "string",
+          "description": "Optional high-impact action taxonomy category, such as HIA-COMM or HIA-DATA."
+        },
+        "tool_name": {
+          "type": "string",
+          "description": "Tool or API requested for invocation."
+        },
+        "tool_operation": {
+          "type": "string",
+          "description": "Specific tool operation, endpoint, method, or command."
+        },
+        "argument_digest": {
+          "type": "string",
+          "description": "Privacy-preserving digest or reference for tool arguments when raw arguments should not be stored."
+        },
+        "external_effect_expected": {
+          "type": "boolean",
+          "description": "Whether the action was expected to create external or persistent effects."
+        }
+      }
+    },
+    "authorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision",
+        "policy_id"
+      ],
+      "properties": {
+        "decision": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "deny",
+            "requires_human_approval",
+            "requires_additional_verification",
+            "escalate"
+          ],
+          "description": "Authorization decision at the action boundary."
+        },
+        "policy_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Policy, rule, workflow, or decision point used for authorization."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable reason for the authorization decision."
+        },
+        "decision_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the authorization decision."
+        },
+        "trusted_inputs_used": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Trusted inputs used for the authorization decision."
+        },
+        "untrusted_inputs_excluded": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Untrusted inputs explicitly excluded from authorization."
+        },
+        "revocation_state_checked": {
+          "type": "boolean",
+          "description": "Whether revocation state was checked before allowing or executing the action."
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "approval_required"
+      ],
+      "properties": {
+        "approval_required": {
+          "type": "boolean",
+          "description": "Whether human approval was required."
+        },
+        "approval_id": {
+          "type": "string",
+          "description": "Identifier for the approval record."
+        },
+        "approver_id": {
+          "type": "string",
+          "description": "Identifier for the approver."
+        },
+        "approval_decision": {
+          "type": "string",
+          "enum": [
+            "approved",
+            "denied",
+            "expired",
+            "not_required",
+            "unknown"
+          ],
+          "description": "Approval outcome."
+        },
+        "approval_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of approval decision."
+        },
+        "approval_context_presented": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Information shown to the human approver."
+        }
+      }
+    },
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "input_sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/input_source"
+          },
+          "description": "Input, memory, retrieval, or context sources that may have influenced the action."
+        },
+        "untrusted_content_influenced_action": {
+          "type": "boolean",
+          "description": "Whether untrusted content materially influenced the action."
+        },
+        "retrieved_or_remembered_content_material": {
+          "type": "boolean",
+          "description": "Whether retrieved or remembered content materially influenced the high-impact action."
+        },
+        "correlation_id": {
+          "type": "string",
+          "description": "Correlation ID for linking related workflow, trace, or action events."
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "Trace ID for distributed tracing or workflow reconstruction."
+        }
+      }
+    },
+    "input_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_type",
+        "trust_level"
+      ],
+      "properties": {
+        "source_type": {
+          "type": "string",
+          "description": "Type of input source, such as user_instruction, external_email_body, retrieved_web_content, memory, tool_result, system_policy, or approval_record."
+        },
+        "source_id": {
+          "type": "string",
+          "description": "Identifier or reference for the source."
+        },
+        "trust_level": {
+          "type": "string",
+          "enum": [
+            "trusted",
+            "untrusted",
+            "mixed",
+            "unknown"
+          ],
+          "description": "Trust classification of the source."
+        },
+        "provenance": {
+          "type": "string",
+          "description": "Provenance metadata, URI, source description, or reference."
+        },
+        "content_digest": {
+          "type": "string",
+          "description": "Privacy-preserving digest of source content."
+        },
+        "materially_influenced_action": {
+          "type": "boolean",
+          "description": "Whether this source materially influenced the requested action."
+        }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "external_effect"
+      ],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "allowed",
+            "allowed_after_approval",
+            "denied",
+            "failed",
+            "partially_completed",
+            "quarantined",
+            "revoked"
+          ],
+          "description": "Final result status of the action."
+        },
+        "tool_invoked": {
+          "type": "string",
+          "description": "Tool actually invoked, if any."
+        },
+        "tool_result_reference": {
+          "type": "string",
+          "description": "Reference to tool output, result record, transaction ID, or execution log."
+        },
+        "external_effect": {
+          "type": "boolean",
+          "description": "Whether the action created an external, persistent, or system state-changing effect."
+        },
+        "error_code": {
+          "type": "string",
+          "description": "Error code if the action failed."
+        },
+        "result_digest": {
+          "type": "string",
+          "description": "Privacy-preserving digest of the result, where raw output should not be stored."
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "retention_class"
+      ],
+      "properties": {
+        "evidence_id": {
+          "type": "string",
+          "description": "Identifier for this evidence record."
+        },
+        "evidence_hash": {
+          "type": "string",
+          "description": "Hash of the evidence event or related evidence bundle."
+        },
+        "retention_class": {
+          "type": "string",
+          "description": "Retention class or policy for this evidence event."
+        },
+        "tamper_evidence": {
+          "type": "string",
+          "enum": [
+            "none",
+            "signed_log_entry",
+            "append_only_log",
+            "transparency_log",
+            "hash_chain",
+            "other"
+          ],
+          "description": "Tamper-evidence mechanism used, if any."
+        },
+        "evidence_location": {
+          "type": "string",
+          "description": "Location or reference for stored evidence."
+        },
+        "privacy_notes": {
+          "type": "string",
+          "description": "Notes on privacy-preserving storage, redaction, minimization, or access control."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "revocation_triggered": {
+          "type": "boolean",
+          "description": "Whether revocation was triggered as a result of this event."
+        },
+        "revocation_reference": {
+          "type": "string",
+          "description": "Reference to revocation action or record."
+        },
+        "isolation_triggered": {
+          "type": "boolean",
+          "description": "Whether agent, workflow, tool, memory, or delegation isolation was triggered."
+        },
+        "isolation_reference": {
+          "type": "string",
+          "description": "Reference to isolation action or incident record."
+        },
+        "incident_reference": {
+          "type": "string",
+          "description": "Reference to related incident, case, or review record."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds an initial JSON Schema for AAEF agentic action evidence events.

This turns the existing evidence event example into a structured draft format that can be reviewed, validated, and used by implementers as a reference for high-impact agentic action evidence.

## Added

- `schemas/agentic-action-evidence-event.schema.json`
- `docs/en/14-evidence-event-schema.md`
- `examples/agentic-action-evidence-event.minimal.json`
- `examples/agentic-action-evidence-event.valid.json`

## Design focus

The schema is designed to capture:

- agent identity
- agent instance identity
- principal binding
- delegated authority
- requested action
- authorization decision
- approval reference
- trusted and untrusted input sources
- result
- evidence metadata
- revocation and isolation references

## Notes

This is an initial draft for public review and is intended for the AAEF v0.2.0 milestone.

The schema validates event structure only. It does not prove that an action was safe, authorized correctly, or compliant with any standard.

## Review focus

Feedback is welcome on:

- which fields should be required
- whether `delegation` should be required for all high-impact actions
- how privacy-preserving evidence should be represented
- how cross-agent evidence should be represented
- whether denied actions and executed actions should share the same schema
- how principal context degradation should be represented in future versions