### PR TITLE
Improve repository reviewability for v0.2 drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased / v0.2.0 Public Review Draft — Work in Progress
+
+- Added preliminary OWASP Agentic Top 10 2026 mapping.
+- Added initial Agentic Action Evidence Event JSON Schema.
+- Added minimal and valid evidence event examples.
+- Added High-Impact Action Taxonomy draft.
+
 ## v0.1.5 Public Review Draft
 
 - Added the public GitHub repository URL to `CITATION.cff`.

--- a/README.md
+++ b/README.md
@@ -79,11 +79,17 @@ AAEF is intended for:
 
 ## Document Status
 
-This repository contains **AAEF v0.1 Public Review Draft**.
+This repository contains the **AAEF v0.1 Public Review Draft**, with selected **v0.2.0 work-in-progress draft artifacts** already merged for public review.
 
-This draft is intentionally incomplete. It is published to establish the core concepts, terminology, control domains, initial control requirements, and review direction for an open action assurance profile for agentic AI systems.
+The v0.1 control catalog remains the current control baseline.
 
-This revision incorporates early review feedback by clarifying evidence requirements, unifying maturity levels, strengthening prompt-injection-related controls, and making the control CSV the source of truth.
+The v0.2.0 work-in-progress materials currently include:
+
+- preliminary OWASP Agentic Top 10 2026 mapping,
+- initial Agentic Action Evidence Event JSON Schema,
+- High-Impact Action Taxonomy draft.
+
+These v0.2 materials are not yet a finalized release. They are provided to support review, implementation feedback, and future control expansion.
 
 Feedback, issues, and pull requests are welcome.
 
@@ -98,6 +104,9 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 ```text
 .
 ├── README.md
+├── README.ja.md
+├── README.zh-CN.md
+├── README.ko.md
 ├── LICENSE.md
 ├── CITATION.cff
 ├── CHANGELOG.md
@@ -117,9 +126,19 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │       ├── 07-control-requirements.md
 │       ├── 08-assessment-methodology.md
 │       ├── 09-relationship-to-existing-frameworks.md
-│       └── 10-maintenance-and-validation.md
+│       ├── 10-maintenance-and-validation.md
+│       ├── 11-high-impact-action-taxonomy.md
+│       └── 14-evidence-event-schema.md
+├── mappings/
+│   └── owasp-agentic-top10-2026.md
+├── schemas/
+│   └── agentic-action-evidence-event.schema.json
+├── taxonomies/
+│   └── high-impact-action-taxonomy-v0.2-draft.csv
 ├── examples/
 │   ├── agentic-action-evidence-event.json
+│   ├── agentic-action-evidence-event.minimal.json
+│   ├── agentic-action-evidence-event.valid.json
 │   └── attack-control-mapping.md
 ├── tools/
 │   └── validate_control_catalog.py

--- a/docs/en/11-high-impact-action-taxonomy.md
+++ b/docs/en/11-high-impact-action-taxonomy.md
@@ -10,6 +10,25 @@ Machine-readable draft:
 
 This taxonomy is intended for AAEF v0.2.0 discussion and review. It is not a certification scheme, legal standard, or exhaustive list of all high-risk agentic AI actions.
 
+## Machine-Readable CSV
+
+The taxonomy is also provided as a machine-readable CSV file:
+
+- `taxonomies/high-impact-action-taxonomy-v0.2-draft.csv`
+
+The CSV includes the following columns:
+
+- `Category ID`
+- `Category Name`
+- `Definition`
+- `Example Actions`
+- `Typical Impact`
+- `Recommended Baseline`
+- `Key AAEF Control Areas`
+- `Suggested Evidence`
+
+The CSV is intended to support assessment tooling, review worksheets, mappings, and future validation workflows.
+
 ## Purpose
 
 AAEF v0.1.x requires organizations to define high-impact agentic actions.


### PR DESCRIPTION
## Summary

Improves repository reviewability for the current v0.2.0 work-in-progress draft materials.

This update makes the repository entry points reflect recently merged draft artifacts, including the OWASP mapping, Evidence Event Schema, and High-Impact Action Taxonomy.

## Updated

- `README.md`
- `CHANGELOG.md`
- `docs/en/11-high-impact-action-taxonomy.md`

## Changes

- Updated README Document Status to mention v0.2.0 work-in-progress draft artifacts.
- Updated README Repository Structure to include:
  - `mappings/`
  - `schemas/`
  - `taxonomies/`
  - `docs/en/11-high-impact-action-taxonomy.md`
  - `docs/en/14-evidence-event-schema.md`
- Added an Unreleased / v0.2.0 Work in Progress section to `CHANGELOG.md`.
- Added a Machine-Readable CSV section to the High-Impact Action Taxonomy document.

## Notes

This PR does not change the v0.1 control catalog baseline.

It is intended to make the repository easier to review from the outside now that v0.2 draft artifacts have started landing in `main`.