### PR TITLE
Update README repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │       ├── 09-relationship-to-existing-frameworks.md
 │       ├── 10-maintenance-and-validation.md
 │       ├── 11-high-impact-action-taxonomy.md
-│       └── 14-evidence-event-schema.md
+│       ├── 14-evidence-event-schema.md
+│       └── 15-v02-control-expansion-notes.md
 ├── mappings/
 │   └── owasp-agentic-top10-2026.md
 ├── schemas/
@@ -139,12 +140,15 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │   ├── agentic-action-evidence-event.json
 │   ├── agentic-action-evidence-event.minimal.json
 │   ├── agentic-action-evidence-event.valid.json
+│   ├── agentic-action-evidence-event.invalid.json
 │   └── attack-control-mapping.md
 ├── tools/
-│   └── validate_control_catalog.py
+│   ├── validate_control_catalog.py
+│   └── validate_evidence_schema.py
 └── .github/
     └── workflows/
-        └── validate-control-catalog.yml
+        ├── validate-control-catalog.yml
+        └── validate-evidence-schema.yml
 ```
 
 ## Citation


### PR DESCRIPTION
## Summary

Updates the README Repository Structure section to reflect recently merged v0.2 work-in-progress artifacts and validation tooling.

## Updated

- `README.md`

## Changes

Added repository structure entries for:

- `docs/en/15-v02-control-expansion-notes.md`
- `examples/agentic-action-evidence-event.invalid.json`
- `tools/validate_evidence_schema.py`
- `.github/workflows/validate-evidence-schema.yml`

## Notes

This is a documentation-only update.

The framework controls, schemas, mappings, and validation behavior are unchanged.