### PR TITLE
Expand evidence event schema

### DIFF
--- a/docs/en/14-evidence-event-schema.md
+++ b/docs/en/14-evidence-event-schema.md
@@ -12,6 +12,7 @@ Examples:
 
 - `examples/agentic-action-evidence-event.minimal.json`
 - `examples/agentic-action-evidence-event.valid.json`
+- `examples/agentic-action-evidence-event.invalid.json`
 
 This schema is intended for AAEF v0.2.0 discussion and review. It is not a certification format and does not guarantee compliance by itself.
 
@@ -91,6 +92,42 @@ The schema includes fields such as:
 
 These fields support reconstruction of action sequences, delegation chains, and response actions.
 
+
+### 6. Evidence assertions should identify their source and limits
+
+Some evidence fields are assertions rather than direct facts.
+
+For example, `untrusted_content_influenced_action: false` is only meaningful if the event also shows who or what determined that assertion, what method was used, the confidence level, and known limitations.
+
+The schema therefore supports `input_influence_assessment` to record:
+
+- `determined_by`
+- `method`
+- `confidence`
+- `limitations`
+
+This is intended to avoid treating model self-reporting as sufficient evidence for high-impact actions.
+
+### 7. Authorization decisions should be bound to actions
+
+AAEF separates model output from authority.
+
+For high-impact actions, an authorization decision should not be treated as a free-floating `allow` value. It should be bound to the action, principal, resource, authority scope, and issuing decision point where feasible.
+
+The schema therefore supports `authorization_decision_artifact`.
+
+### 8. Non-execution and override events are evidence
+
+An action that was denied, deferred, escalated, frozen, or safely terminated may still be security-relevant.
+
+The schema therefore supports optional sections for:
+
+- `non_execution`
+- `reauthorization`
+- `override`
+
+These sections support review of denied actions, safe termination, scoped reauthorization, human override, and break-glass operations.
+
 ## Required Top-Level Fields
 
 The initial schema requires:
@@ -139,6 +176,87 @@ AAEF v0.1.x included:
 That example demonstrated the concept.
 
 This schema turns the evidence event into a structured draft format that can be validated and reviewed.
+
+
+## v0.2 Draft Expansion Sections
+
+The current v0.2 draft schema includes optional sections and objects for recently added control areas.
+
+### Authorization Decision Artifact
+
+`authorization.authorization_decision_artifact` can be used to record an action-bound decision artifact.
+
+It may include:
+
+- `decision_id`
+- `decision`
+- `bound_action_digest`
+- `principal_id`
+- `authority_scope`
+- `resource`
+- `expires_at`
+- `issuer`
+- `signature_reference`
+
+This supports integrity between authorization and tool dispatch by making it easier to detect decision reuse, replay, or substitution.
+
+### Intent Alignment
+
+`authorization.intent_alignment` can be used to record how intent-authority alignment was evaluated.
+
+It may include:
+
+- `principal_intent_reference`
+- `policy_constraints_used`
+- `machine_enforceable_policy_reference`
+- `human_readable_policy_summary`
+- `alignment_decision`
+- `alignment_reason`
+- `model_self_assessment_only`
+
+The field `model_self_assessment_only` is included to make reliance on model self-assessment visible. For high-assurance actions, implementers should avoid relying solely on model self-assessment.
+
+### State Checks
+
+`authorization.state_checks` can be used to record runtime state checks that affected authorization.
+
+Examples include:
+
+- revocation state,
+- incident status,
+- system health,
+- approved vendor status,
+- account state,
+- fraud risk,
+- market state,
+- or other organization-defined state sources.
+
+### Input Influence Assessment
+
+`context.input_influence_assessment` can be used to record who or what determined whether untrusted content influenced an action.
+
+This is more reviewable than a standalone boolean because it records method, confidence, and limitations.
+
+### Delegation Lineage
+
+`delegation.delegation_lineage` can be used to record lineage nodes for reconstructing upstream and downstream authority decisions.
+
+AAEF requires reconstructability, not a specific graph database or tracing tool.
+
+### Human Override
+
+`override` can be used to record human override or break-glass context.
+
+It is intended to be append-only and linked to original actions or incidents, not to overwrite prior evidence.
+
+### Non-Execution
+
+`non_execution` can be used to record denied, deferred, escalated, frozen, or safely terminated high-impact actions.
+
+### Reauthorization
+
+`reauthorization` can be used to record scoped reauthorization requests, retry counts, principal reconfirmation, and reauthorization decisions.
+
 
 ## Validation
 
@@ -196,4 +314,7 @@ Future versions may add:
 - High-Impact Action Taxonomy integration
 - JSON Schema validation workflow
 - example invalid events
+- Evidence assertion source and input influence determination
+- Authorization decision artifact profile
+- Override, non-execution, and reauthorization examples
 - schema versioning policy

--- a/examples/agentic-action-evidence-event.valid.json
+++ b/examples/agentic-action-evidence-event.valid.json
@@ -38,7 +38,24 @@
       "allowed_purposes": [
         "office_supplies_procurement"
       ]
-    }
+    },
+    "delegation_lineage": [
+      {
+        "lineage_node_id": "lineage_001",
+        "upstream_action_id": "act_20260425_000000",
+        "upstream_agent_id": "agent.procurement.manager",
+        "downstream_agent_id": "agent.procurement.assistant",
+        "delegated_scope": [
+          "purchase_order.prepare"
+        ],
+        "delegated_constraints": [
+          "max_amount:1000.00",
+          "allowed_resource:vendor_xyz"
+        ],
+        "delegation_decision": "attenuated",
+        "decision_reference": "del_decision_001"
+      }
+    ]
   },
   "requested_action": {
     "action_type": "purchase_order.create",
@@ -66,7 +83,49 @@
       "retrieved_web_content",
       "external_email_body"
     ],
-    "revocation_state_checked": true
+    "revocation_state_checked": true,
+    "authorization_decision_artifact": {
+      "decision_id": "authz_20260425_000001",
+      "decision": "requires_human_approval",
+      "bound_action_digest": "sha256:example-bound-action-digest",
+      "principal_id": "user_12345",
+      "authority_scope": [
+        "vendor.quote.request",
+        "purchase_order.prepare"
+      ],
+      "resource": "vendor_xyz",
+      "expires_at": "2026-04-25T00:10:00Z",
+      "issuer": "policy_engine.procurement",
+      "signature_reference": "sig_20260425_000001"
+    },
+    "intent_alignment": {
+      "principal_intent_reference": "req_20260425_000001",
+      "policy_constraints_used": [
+        "approved_vendor_policy",
+        "procurement_limit_policy"
+      ],
+      "machine_enforceable_policy_reference": "policy.procurement.high_risk_actions.v1",
+      "human_readable_policy_summary": "Use approved vendors and stay within delegated procurement limits.",
+      "alignment_decision": "aligned",
+      "alignment_reason": "Requested vendor and amount matched structured authority constraints.",
+      "model_self_assessment_only": false
+    },
+    "state_checks": [
+      {
+        "state_source": "revocation_state",
+        "state_snapshot_id": "rev_state_20260425_000001",
+        "state_checked_at": "2026-04-25T00:00:55Z",
+        "state_result": "passed",
+        "conditional_policy_reference": "policy.revocation.check.v1"
+      },
+      {
+        "state_source": "vendor_status",
+        "state_snapshot_id": "vendor_state_vendor_xyz",
+        "state_checked_at": "2026-04-25T00:00:56Z",
+        "state_result": "passed",
+        "conditional_policy_reference": "policy.approved_vendor.v1"
+      }
+    ]
   },
   "approval": {
     "approval_required": true,
@@ -107,7 +166,14 @@
     "untrusted_content_influenced_action": false,
     "retrieved_or_remembered_content_material": false,
     "correlation_id": "corr_abc123",
-    "trace_id": "trace_xyz789"
+    "trace_id": "trace_xyz789",
+    "input_influence_assessment": {
+      "untrusted_content_influenced_action": false,
+      "determined_by": "runtime_input_tracker",
+      "method": "source_tracking",
+      "confidence": "medium",
+      "limitations": "Semantic influence cannot be fully excluded; assessment is based on recorded source use and authorization inputs."
+    }
   },
   "result": {
     "status": "allowed_after_approval",
@@ -128,5 +194,17 @@
     "revocation_triggered": false,
     "isolation_triggered": false,
     "incident_reference": "none"
+  },
+  "non_execution": {
+    "non_execution_decision": "not_applicable",
+    "reason": "Action proceeded after required approval."
+  },
+  "reauthorization": {
+    "reauthorization_requested": false,
+    "reauthorization_decision": "not_requested",
+    "retry_count": 0
+  },
+  "override": {
+    "override_triggered": false
   }
 }

--- a/schemas/agentic-action-evidence-event.schema.json
+++ b/schemas/agentic-action-evidence-event.schema.json
@@ -49,7 +49,12 @@
         "agentic_action_allowed",
         "agentic_action_executed",
         "agentic_action_failed",
-        "agentic_action_revoked"
+        "agentic_action_revoked",
+        "agentic_action_deferred",
+        "agentic_action_escalated",
+        "authority_frozen",
+        "human_override_recorded",
+        "reauthorization_requested"
       ],
       "description": "Type of evidence event.",
       "default": "agentic_action_executed"
@@ -88,6 +93,15 @@
       "type": "object",
       "description": "Implementation-specific extension fields. Extensions should not replace required AAEF fields.",
       "additionalProperties": true
+    },
+    "override": {
+      "$ref": "#/$defs/override"
+    },
+    "non_execution": {
+      "$ref": "#/$defs/non_execution"
+    },
+    "reauthorization": {
+      "$ref": "#/$defs/reauthorization"
     }
   },
   "$defs": {
@@ -235,6 +249,13 @@
               "description": "Allowed purposes or purpose categories."
             }
           }
+        },
+        "delegation_lineage": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/delegation_lineage_node"
+          },
+          "description": "Optional lineage nodes for reconstructing upstream and downstream authority transfer."
         }
       }
     },
@@ -311,7 +332,10 @@
             "deny",
             "requires_human_approval",
             "requires_additional_verification",
-            "escalate"
+            "escalate",
+            "defer",
+            "freeze",
+            "reauthorization_required"
           ],
           "description": "Authorization decision at the action boundary."
         },
@@ -346,6 +370,19 @@
         "revocation_state_checked": {
           "type": "boolean",
           "description": "Whether revocation state was checked before allowing or executing the action."
+        },
+        "authorization_decision_artifact": {
+          "$ref": "#/$defs/authorization_decision_artifact"
+        },
+        "intent_alignment": {
+          "$ref": "#/$defs/intent_alignment"
+        },
+        "state_checks": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/state_check"
+          },
+          "description": "Runtime state checks used or considered for authorization."
         }
       }
     },
@@ -419,6 +456,9 @@
         "trace_id": {
           "type": "string",
           "description": "Trace ID for distributed tracing or workflow reconstruction."
+        },
+        "input_influence_assessment": {
+          "$ref": "#/$defs/input_influence_assessment"
         }
       }
     },
@@ -479,7 +519,12 @@
             "failed",
             "partially_completed",
             "quarantined",
-            "revoked"
+            "revoked",
+            "deferred",
+            "escalated",
+            "frozen",
+            "safely_terminated",
+            "reauthorization_requested"
           ],
           "description": "Final result status of the action."
         },
@@ -569,6 +614,450 @@
         "incident_reference": {
           "type": "string",
           "description": "Reference to related incident, case, or review record."
+        }
+      }
+    },
+    "delegation_lineage_node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "lineage_node_id",
+        "delegation_decision"
+      ],
+      "properties": {
+        "lineage_node_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier for this lineage node."
+        },
+        "upstream_action_id": {
+          "type": "string",
+          "description": "Identifier for the upstream action, if applicable."
+        },
+        "upstream_agent_id": {
+          "type": "string",
+          "description": "Identifier for the upstream agent, if applicable."
+        },
+        "downstream_agent_id": {
+          "type": "string",
+          "description": "Identifier for the downstream agent, if applicable."
+        },
+        "delegated_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Scope delegated at this lineage node."
+        },
+        "delegated_constraints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Human-readable or referenced constraints preserved at this lineage node."
+        },
+        "delegation_decision": {
+          "type": "string",
+          "enum": [
+            "granted",
+            "attenuated",
+            "denied",
+            "expired",
+            "revoked",
+            "unknown"
+          ],
+          "description": "Delegation decision at this lineage node."
+        },
+        "decision_reference": {
+          "type": "string",
+          "description": "Reference to the delegation decision or evidence record."
+        }
+      }
+    },
+    "authorization_decision_artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "decision_id",
+        "decision",
+        "bound_action_digest",
+        "issuer"
+      ],
+      "properties": {
+        "decision_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Identifier for the authorization decision artifact."
+        },
+        "decision": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "deny",
+            "requires_human_approval",
+            "requires_additional_verification",
+            "escalate",
+            "defer",
+            "freeze",
+            "reauthorization_required"
+          ],
+          "description": "Decision represented by the artifact."
+        },
+        "bound_action_digest": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Digest binding the decision to the specific action request."
+        },
+        "principal_id": {
+          "type": "string",
+          "description": "Principal identifier bound to the decision."
+        },
+        "authority_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Authority scope bound to the decision."
+        },
+        "resource": {
+          "type": "string",
+          "description": "Resource bound to the decision."
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Decision artifact expiration time."
+        },
+        "issuer": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Trusted decision issuer, such as a policy engine or authorization service."
+        },
+        "signature_reference": {
+          "type": "string",
+          "description": "Reference to signature, attestation, or integrity metadata for the artifact."
+        }
+      }
+    },
+    "intent_alignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alignment_decision"
+      ],
+      "properties": {
+        "principal_intent_reference": {
+          "type": "string",
+          "description": "Reference to the principal intent, request, ticket, workflow, or business process."
+        },
+        "policy_constraints_used": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Policy constraints used to evaluate intent-authority alignment."
+        },
+        "machine_enforceable_policy_reference": {
+          "type": "string",
+          "description": "Reference to a machine-enforceable policy used for the decision."
+        },
+        "human_readable_policy_summary": {
+          "type": "string",
+          "description": "Human-readable summary used for review. This should not replace the machine-enforceable policy reference."
+        },
+        "alignment_decision": {
+          "type": "string",
+          "enum": [
+            "aligned",
+            "not_aligned",
+            "unclear",
+            "not_evaluated"
+          ],
+          "description": "Intent-authority alignment outcome."
+        },
+        "alignment_reason": {
+          "type": "string",
+          "description": "Reason or review note for the alignment decision."
+        },
+        "model_self_assessment_only": {
+          "type": "boolean",
+          "description": "Whether the alignment decision relied only on model self-assessment. For high-assurance actions this should generally be false."
+        }
+      }
+    },
+    "state_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state_source",
+        "state_result"
+      ],
+      "properties": {
+        "state_source": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Trusted state source used for authorization, such as incident_status, system_health, revocation_state, or fraud_risk."
+        },
+        "state_snapshot_id": {
+          "type": "string",
+          "description": "Reference to the state snapshot used for the decision."
+        },
+        "state_checked_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when state was checked."
+        },
+        "state_result": {
+          "type": "string",
+          "enum": [
+            "passed",
+            "failed",
+            "unknown",
+            "not_checked",
+            "authority_frozen",
+            "escalation_required"
+          ],
+          "description": "Result of the state check."
+        },
+        "conditional_policy_reference": {
+          "type": "string",
+          "description": "Policy reference for state-dependent authorization or freeze behavior."
+        },
+        "freeze_reason": {
+          "type": "string",
+          "description": "Reason authority was frozen, if applicable."
+        }
+      }
+    },
+    "input_influence_assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "determined_by",
+        "method",
+        "confidence"
+      ],
+      "properties": {
+        "untrusted_content_influenced_action": {
+          "type": "boolean",
+          "description": "Assessment of whether untrusted content materially influenced the action."
+        },
+        "determined_by": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Component or actor that determined the input influence assessment."
+        },
+        "method": {
+          "type": "string",
+          "enum": [
+            "runtime_input_tracker",
+            "source_tracking",
+            "taint_tracking",
+            "policy_engine",
+            "human_review",
+            "model_self_assessment",
+            "best_effort",
+            "other"
+          ],
+          "description": "Method used to determine input influence."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "high",
+            "medium",
+            "low",
+            "unknown"
+          ],
+          "description": "Confidence level for the input influence assessment."
+        },
+        "limitations": {
+          "type": "string",
+          "description": "Known limitations of the assessment."
+        }
+      }
+    },
+    "override": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "override_triggered"
+      ],
+      "properties": {
+        "override_triggered": {
+          "type": "boolean",
+          "description": "Whether human override occurred."
+        },
+        "override_type": {
+          "type": "string",
+          "enum": [
+            "emergency_stop",
+            "manual_reversal",
+            "forced_continuation",
+            "break_glass",
+            "temporary_authority_grant",
+            "other"
+          ],
+          "description": "Type of override."
+        },
+        "override_actor_id": {
+          "type": "string",
+          "description": "Human actor or privileged role that performed the override."
+        },
+        "override_reason": {
+          "type": "string",
+          "description": "Reason for override."
+        },
+        "override_authority": {
+          "type": "string",
+          "description": "Authority or role under which the override was performed."
+        },
+        "override_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Scope affected by the override."
+        },
+        "override_timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of override."
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expiration time for temporary override authority."
+        },
+        "post_review_required": {
+          "type": "boolean",
+          "description": "Whether post-review is required."
+        },
+        "linked_action_id": {
+          "type": "string",
+          "description": "Action or workflow linked to the override."
+        },
+        "incident_reference": {
+          "type": "string",
+          "description": "Related incident or case reference."
+        }
+      }
+    },
+    "non_execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "non_execution_decision"
+      ],
+      "properties": {
+        "non_execution_decision": {
+          "type": "string",
+          "enum": [
+            "denied",
+            "deferred",
+            "escalated",
+            "frozen",
+            "safely_terminated",
+            "not_applicable"
+          ],
+          "description": "Decision describing why execution did not proceed."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Human-readable reason for non-execution."
+        },
+        "ambiguity_type": {
+          "type": "string",
+          "enum": [
+            "deterministic",
+            "semantic",
+            "mixed",
+            "none",
+            "unknown"
+          ],
+          "description": "Type of ambiguity involved, if any."
+        },
+        "authority_gap": {
+          "type": "string",
+          "description": "Authority gap or missing authority scope, if applicable."
+        },
+        "intent_gap": {
+          "type": "string",
+          "description": "Intent gap, if applicable."
+        },
+        "policy_gap": {
+          "type": "string",
+          "description": "Policy gap, if applicable."
+        },
+        "state_gap": {
+          "type": "string",
+          "description": "State gap, if applicable."
+        },
+        "input_trust_gap": {
+          "type": "string",
+          "description": "Input trust gap, if applicable."
+        },
+        "evidence_gap": {
+          "type": "string",
+          "description": "Evidence gap, if applicable."
+        },
+        "escalation_target": {
+          "type": "string",
+          "description": "Escalation target for deferred or escalated action."
+        },
+        "linked_action_id": {
+          "type": "string",
+          "description": "Related action ID."
+        }
+      }
+    },
+    "reauthorization": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "reauthorization_requested": {
+          "type": "boolean",
+          "description": "Whether reauthorization was requested."
+        },
+        "reauthorization_request_id": {
+          "type": "string",
+          "description": "Identifier for the reauthorization request."
+        },
+        "denied_action_id": {
+          "type": "string",
+          "description": "Denied or deferred action that led to reauthorization."
+        },
+        "requested_additional_scope": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additional authority scope requested."
+        },
+        "principal_reconfirmation_required": {
+          "type": "boolean",
+          "description": "Whether principal reconfirmation is required."
+        },
+        "approver_or_escalation_target": {
+          "type": "string",
+          "description": "Approver or escalation target."
+        },
+        "retry_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Retry count linked to this action or reauthorization path."
+        },
+        "reauthorization_decision": {
+          "type": "string",
+          "enum": [
+            "approved",
+            "denied",
+            "deferred",
+            "expired",
+            "not_requested",
+            "unknown"
+          ],
+          "description": "Decision on reauthorization request."
         }
       }
     }


### PR DESCRIPTION
## Summary

Expands the AAEF Agentic Action Evidence Event Schema to support newly added v0.2 control areas.

This PR adds optional schema structures for authorization decision artifacts, intent alignment, runtime state checks, input influence assessment, delegation lineage, human override, non-execution, and reauthorization.

## Updated

- `schemas/agentic-action-evidence-event.schema.json`
- `docs/en/14-evidence-event-schema.md`
- `examples/agentic-action-evidence-event.valid.json`

## Added schema support

- `authorization.authorization_decision_artifact`
- `authorization.intent_alignment`
- `authorization.state_checks`
- `context.input_influence_assessment`
- `delegation.delegation_lineage`
- `override`
- `non_execution`
- `reauthorization`

## Design focus

This PR addresses review feedback around evidence assertion source and authorization integrity.

It clarifies that fields such as `untrusted_content_influenced_action` should not be treated as strong evidence unless the event also records who or what determined the assertion, what method was used, confidence level, and known limitations.

It also adds support for action-bound authorization decision artifacts, so authorization decisions do not have to be represented only as free-floating `allow` or `deny` values.

## Validation

Expected validation result:

- `OK: 44 controls validated.`
- `OK: evidence schema and examples validated.`

## Review focus

Feedback is welcome on:

- whether the new sections should remain optional,
- whether `input_influence_assessment` is sufficient to avoid relying on model self-reporting,
- whether `authorization_decision_artifact` should become required for high-impact actions,
- whether override, non-execution, and reauthorization should be top-level sections or nested elsewhere,
- whether the valid example is too large,
- whether additional focused examples should be added later.