### PR TITLE
Update README and changelog for one-page overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added human, delegation, and evidence control expansion entries.
 - Added Assurance Model and Residual Risk Mapping.
 - Added Assessment Quick Start and Assessment Worksheet draft.
+- Added One-page Overview for first-time readers.
 - Updated README repository structure and document status for v0.2 work-in-progress artifacts.
 - Updated citation metadata to use the full author name.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The v0.2.0 work-in-progress materials currently include:
 - expanded Evidence Event Schema sections for v0.2 control areas,
 - High-Impact Action Taxonomy draft,
 - v0.2 Control Expansion Notes,
+- One-page Overview,
 - authorization and revocation control expansion,
 - human, delegation, and evidence control expansion,
 - Assurance Model and Residual Risk Mapping,
@@ -149,6 +150,7 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │       ├── 10-maintenance-and-validation.md
 │       ├── 11-high-impact-action-taxonomy.md
 │       ├── 12-assessment-quick-start.md
+│       ├── 13-one-page-overview.md
 │       ├── 14-evidence-event-schema.md
 │       ├── 15-v02-control-expansion-notes.md
 │       └── 16-assurance-model.md


### PR DESCRIPTION
## Summary

Updates the README and CHANGELOG to include the newly added One-page Overview.

## Updated

- `README.md`
- `CHANGELOG.md`

## Changes

This PR updates the repository entry points to reflect:

- `docs/en/13-one-page-overview.md` in the Repository Structure,
- One-page Overview in the v0.2 work-in-progress artifact list,
- One-page Overview in the Unreleased / v0.2.0 Public Review Draft changelog.

## Notes

This is a documentation navigation update only.

It does not change the control catalog, evidence schema, mappings, taxonomy, or assessment materials.

## Validation

Expected validation result:

- `OK: 44 controls validated.`
- `OK: evidence schema and examples validated.`