### PR TITLE
Update README and changelog for reference architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added Assurance Model and Residual Risk Mapping.
 - Added Assessment Quick Start and Assessment Worksheet draft.
 - Added One-page Overview for first-time readers.
+- Added Reference Architecture and Mermaid diagram source.
 - Updated README repository structure and document status for v0.2 work-in-progress artifacts.
 - Updated citation metadata to use the full author name.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The v0.2.0 work-in-progress materials currently include:
 - High-Impact Action Taxonomy draft,
 - v0.2 Control Expansion Notes,
 - One-page Overview,
+- Reference Architecture,
 - authorization and revocation control expansion,
 - human, delegation, and evidence control expansion,
 - Assurance Model and Residual Risk Mapping,
@@ -153,9 +154,12 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │       ├── 13-one-page-overview.md
 │       ├── 14-evidence-event-schema.md
 │       ├── 15-v02-control-expansion-notes.md
-│       └── 16-assurance-model.md
+│       ├── 16-assurance-model.md
+│       └── 17-reference-architecture.md
 ├── assessment/
 │   └── aaef-assessment-worksheet-v0.2-draft.csv
+├── assets/
+│   └── aaef-reference-architecture.mmd
 ├── mappings/
 │   ├── owasp-agentic-top10-2026.md
 │   ├── threat-control-assurance-mapping.md


### PR DESCRIPTION
## Summary

Updates the README and CHANGELOG to include the newly added Reference Architecture.

## Updated

- `README.md`
- `CHANGELOG.md`

## Changes

This PR updates the repository entry points to reflect:

- `docs/en/17-reference-architecture.md` in the Repository Structure,
- `assets/aaef-reference-architecture.mmd` in the Repository Structure,
- Reference Architecture in the v0.2 work-in-progress artifact list,
- Reference Architecture in the Unreleased / v0.2.0 Public Review Draft changelog.

## Notes

This is a documentation navigation update only.

It does not change the control catalog, evidence schema, mappings, taxonomy, assurance model, or assessment materials.

## Validation

Expected validation result:

- `OK: 44 controls validated.`
- `OK: evidence schema and examples validated.`