### PR TITLE
Improve README onboarding and reading paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,46 @@ AAEF v0.2.0 remains a public review draft. It is not a certification scheme, for
 
 Feedback, issues, and pull requests are welcome.
 
+## Start Here
+
+If you are new to AAEF, start with the documents below:
+
+1. [`docs/en/13-one-page-overview.md`](docs/en/13-one-page-overview.md) — quick mental model and current public review baseline
+2. [`docs/en/02-core-principles.md`](docs/en/02-core-principles.md) — core principles, including “Model output is not authority”
+3. [`docs/en/17-reference-architecture.md`](docs/en/17-reference-architecture.md) — how the model, authorization, enforcement, and evidence layers relate
+4. [`docs/en/06-control-domains.md`](docs/en/06-control-domains.md) — control domain overview
+5. [`docs/en/07-control-requirements.md`](docs/en/07-control-requirements.md) — detailed control requirements
+6. [`docs/en/14-evidence-event-schema.md`](docs/en/14-evidence-event-schema.md) — evidence event schema and evidence model
+7. [`docs/en/12-assessment-quick-start.md`](docs/en/12-assessment-quick-start.md) — how to start reviewing a system using AAEF
+
+## Role-Based Reading Paths
+
+| Reader | Start with | Then read | Deep dive |
+|---|---|---|---|
+| New readers | [`One-page Overview`](docs/en/13-one-page-overview.md) | [`Core Principles`](docs/en/02-core-principles.md) | [`Introduction`](docs/en/00-introduction.md) / [`Scope`](docs/en/01-scope.md) |
+| Implementers | [`Reference Architecture`](docs/en/17-reference-architecture.md) | [`Control Requirements`](docs/en/07-control-requirements.md) | [`Evidence Event Schema`](docs/en/14-evidence-event-schema.md), examples, and validation tools |
+| Security architects | [`Reference Architecture`](docs/en/17-reference-architecture.md) | [`Threat Model`](docs/en/04-threat-model.md) / [`Trust Model`](docs/en/05-trust-model.md) | Controls and mappings |
+| Auditors / assessors | [`Assessment Quick Start`](docs/en/12-assessment-quick-start.md) | [`Control Requirements`](docs/en/07-control-requirements.md) | Assessment worksheet and [`Assurance Model`](docs/en/16-assurance-model.md) |
+| Governance / risk teams | [`One-page Overview`](docs/en/13-one-page-overview.md) | [`High-Impact Action Taxonomy`](docs/en/11-high-impact-action-taxonomy.md) | [`Relationship to Existing Frameworks`](docs/en/09-relationship-to-existing-frameworks.md) and [`Assurance Model`](docs/en/16-assurance-model.md) |
+
+## How the Core Documents Fit Together
+
+| Document | What it answers | Practical role |
+|---|---|---|
+| [`Control Requirements`](docs/en/07-control-requirements.md) | What must be controlled? | Defines requirements, review criteria, and assessment items |
+| [`Reference Architecture`](docs/en/17-reference-architecture.md) | Where should controls be enforced? | Shows responsibility separation across model, authorization, dispatch, tools, and evidence |
+| [`Evidence Event Schema`](docs/en/14-evidence-event-schema.md) | What evidence should exist? | Defines structured evidence for audit logs, SIEM events, incident reconstruction, and evidence review |
+| [`Assessment Worksheet`](assessment/aaef-assessment-worksheet-v0.2-draft.csv) | How should controls be reviewed? | Supports applicability review, evidence review, findings, residual risk, and remediation tracking |
+
+In short:
+
+```text
+Control Requirements define what must be true.
+Reference Architecture shows where those controls are enforced.
+Evidence Event Schema records what happened and why.
+Assessment Worksheet helps review whether the controls and evidence exist.
+```
+
 ## Control Catalog Source of Truth
 
 The control catalog CSV is the machine-readable source of truth for control IDs, requirement text, objectives, applicability, testing procedures, evidence examples, and maturity classification.


### PR DESCRIPTION
## Summary

This PR improves README onboarding for first-time readers.

It adds:

- Start Here section
- Role-Based Reading Paths
- How the Core Documents Fit Together

## Rationale

Post-v0.2.0 public review feedback noted that AAEF already has strong materials, but first-time readers may not immediately know where to start or which documents are most relevant to their role.

This PR makes the README function more clearly as an entry point for:

- new readers
- implementers
- security architects
- auditors / assessors
- governance and risk teams

## Validation

- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`

## Related issue

Closes #<issue-number>