### PR TITLE
Add high-impact evidence event example

### DIFF
--- a/examples/agentic-action-evidence-event.high-impact.json
+++ b/examples/agentic-action-evidence-event.high-impact.json
@@ -1,0 +1,220 @@
+{
+  "schema": "aaef.agentic_action_evidence_event",
+  "schema_version": "0.2.0-draft",
+  "action_id": "act_20260426_high_impact_000001",
+  "timestamp": "2026-04-26T00:00:00Z",
+  "event_type": "agentic_action_executed",
+  "agent": {
+    "agent_id": "agent.procurement.assistant",
+    "agent_instance_id": "inst_HIGH_IMPACT_EXAMPLE",
+    "agent_product": "Example Procurement Agent",
+    "operator_id": "org.example",
+    "issuer_id": "issuer.example",
+    "runtime_environment": "prod/procurement/workflow"
+  },
+  "principal": {
+    "principal_type": "human_user",
+    "principal_id": "user_12345",
+    "principal_context": "procurement_request",
+    "principal_context_id": "req_20260426_high_impact_000001"
+  },
+  "delegation": {
+    "delegation_chain_id": "del_chain_high_impact_001",
+    "parent_action_id": "act_20260426_high_impact_000000",
+    "authority_scope": [
+      "vendor.quote.request",
+      "purchase_order.prepare"
+    ],
+    "constraints": {
+      "max_amount": "1000.00",
+      "currency": "USD",
+      "expires_at": "2026-04-26T01:00:00Z",
+      "max_count": 1,
+      "max_delegation_depth": 1,
+      "redelegation_allowed": false,
+      "allowed_resources": [
+        "vendor_xyz"
+      ],
+      "allowed_purposes": [
+        "office_supplies_procurement"
+      ]
+    },
+    "delegation_lineage": [
+      {
+        "lineage_node_id": "lineage_001",
+        "upstream_action_id": "act_20260426_high_impact_000000",
+        "upstream_agent_id": "agent.procurement.manager",
+        "downstream_agent_id": "agent.procurement.assistant",
+        "delegated_scope": [
+          "purchase_order.prepare"
+        ],
+        "delegated_constraints": [
+          "max_amount:1000.00",
+          "allowed_resource:vendor_xyz"
+        ],
+        "delegation_decision": "attenuated",
+        "decision_reference": "del_decision_001"
+      }
+    ]
+  },
+  "requested_action": {
+    "action_type": "purchase_order.create",
+    "resource": "vendor_xyz",
+    "purpose": "office_supplies_procurement",
+    "risk_level": "high",
+    "high_impact_category": "HIA-FIN",
+    "tool_name": "procurement_api",
+    "tool_operation": "create_purchase_order",
+    "argument_digest": "sha256:high-impact-example-argument-digest",
+    "external_effect_expected": true
+  },
+  "authorization": {
+    "decision": "requires_human_approval",
+    "policy_id": "policy.procurement.high_risk_actions.v1",
+    "reason": "purchase_order.create exceeds autonomous execution authority",
+    "decision_timestamp": "2026-04-26T00:01:00Z",
+    "trusted_inputs_used": [
+      "policy",
+      "authority_scope",
+      "principal_context",
+      "risk_classification"
+    ],
+    "untrusted_inputs_excluded": [
+      "retrieved_web_content",
+      "external_email_body"
+    ],
+    "revocation_state_checked": true,
+    "authorization_decision_artifact": {
+      "decision_id": "authz_20260426_high_impact_000001",
+      "decision": "requires_human_approval",
+      "bound_action_digest": "sha256:high-impact-example-bound-action-digest",
+      "principal_id": "user_12345",
+      "authority_scope": [
+        "vendor.quote.request",
+        "purchase_order.prepare"
+      ],
+      "resource": "vendor_xyz",
+      "expires_at": "2026-04-26T00:10:00Z",
+      "issuer": "policy_engine.procurement",
+      "signature_reference": "sig_20260426_high_impact_000001"
+    },
+    "intent_alignment": {
+      "principal_intent_reference": "req_20260426_high_impact_000001",
+      "policy_constraints_used": [
+        "approved_vendor_policy",
+        "procurement_limit_policy"
+      ],
+      "machine_enforceable_policy_reference": "policy.procurement.high_risk_actions.v1",
+      "human_readable_policy_summary": "Use approved vendors and stay within delegated procurement limits.",
+      "alignment_decision": "aligned",
+      "alignment_reason": "Requested vendor and amount matched structured authority constraints.",
+      "model_self_assessment_only": false
+    },
+    "state_checks": [
+      {
+        "state_source": "revocation_state",
+        "state_snapshot_id": "rev_state_20260425_000001",
+        "state_checked_at": "2026-04-26T00:00:55Z",
+        "state_result": "passed",
+        "conditional_policy_reference": "policy.revocation.check.v1"
+      },
+      {
+        "state_source": "vendor_status",
+        "state_snapshot_id": "vendor_state_vendor_xyz",
+        "state_checked_at": "2026-04-26T00:00:56Z",
+        "state_result": "passed",
+        "conditional_policy_reference": "policy.approved_vendor.v1"
+      }
+    ]
+  },
+  "approval": {
+    "approval_required": true,
+    "approval_id": "approval_high_impact_000001",
+    "approver_id": "manager_456",
+    "approval_decision": "approved",
+    "approval_timestamp": "2026-04-26T00:05:00Z",
+    "approval_context_presented": [
+      "agent_id",
+      "principal_id",
+      "requested_action",
+      "resource",
+      "purpose",
+      "risk_level",
+      "authority_scope",
+      "expected_external_effect"
+    ]
+  },
+  "context": {
+    "input_sources": [
+      {
+        "source_type": "user_instruction",
+        "source_id": "req_20260426_high_impact_000001",
+        "trust_level": "trusted",
+        "provenance": "internal_workflow",
+        "content_digest": "sha256:example-user-instruction-digest",
+        "materially_influenced_action": true
+      },
+      {
+        "source_type": "retrieved_web_content",
+        "source_id": "web_001",
+        "trust_level": "untrusted",
+        "provenance": "external_vendor_page",
+        "content_digest": "sha256:example-retrieved-content-digest",
+        "materially_influenced_action": false
+      }
+    ],
+    "untrusted_content_influenced_action": false,
+    "retrieved_or_remembered_content_material": false,
+    "correlation_id": "corr_high_impact_000001",
+    "trace_id": "trace_high_impact_000001",
+    "input_influence_assessment": {
+      "untrusted_content_influenced_action": false,
+      "determined_by": "runtime_input_tracker",
+      "method": "source_tracking",
+      "confidence": "medium",
+      "limitations": "Semantic influence cannot be fully excluded; assessment is based on recorded source use, trusted authorization inputs, and runtime tracking."
+    }
+  },
+  "result": {
+    "status": "allowed_after_approval",
+    "tool_invoked": "procurement_api.create_purchase_order",
+    "tool_result_reference": "po_000123",
+    "external_effect": true,
+    "result_digest": "sha256:high-impact-example-result-digest"
+  },
+  "evidence": {
+    "evidence_id": "ev_20260426_high_impact_000001",
+    "evidence_hash": "sha256:high-impact-example-evidence-hash",
+    "retention_class": "high_impact_action",
+    "tamper_evidence": "signed_log_entry",
+    "evidence_location": "evidence-store://aaef/events/act_20260426_high_impact_000001",
+    "privacy_notes": "Raw tool arguments are not stored; argument_digest is retained."
+  },
+  "response": {
+    "revocation_triggered": false,
+    "isolation_triggered": false,
+    "incident_reference": "none"
+  },
+  "non_execution": {
+    "non_execution_decision": "not_applicable",
+    "reason": "Action proceeded after required approval."
+  },
+  "reauthorization": {
+    "reauthorization_requested": false,
+    "reauthorization_decision": "not_requested",
+    "retry_count": 0
+  },
+  "override": {
+    "override_triggered": false
+  },
+  "extensions": {
+    "evidence_profile": "high-impact",
+    "profile_notes": "Example high-impact evidence event demonstrating action-bound authorization, human approval, input influence assessment, and tamper-evident evidence references.",
+    "policy_version": "policy.procurement.high_risk_actions.v1",
+    "dispatch_attestation_reference": "dispatch_attest_20260426_high_impact_000001",
+    "canonicalization_method": "implementation-defined",
+    "digest_algorithm": "sha-256",
+    "data_classification": "internal",
+    "redaction_applied": true
+  }
+}

--- a/tools/validate_evidence_schema.py
+++ b/tools/validate_evidence_schema.py
@@ -29,6 +29,7 @@ SCHEMA_PATH = REPO_ROOT / "schemas" / "agentic-action-evidence-event.schema.json
 VALID_EXAMPLES = [
     REPO_ROOT / "examples" / "agentic-action-evidence-event.minimal.json",
     REPO_ROOT / "examples" / "agentic-action-evidence-event.valid.json",
+    REPO_ROOT / "examples" / "agentic-action-evidence-event.high-impact.json",
 ]
 
 INVALID_EXAMPLES = [


### PR DESCRIPTION
## Summary

This PR adds a high-impact Evidence Event Schema example.

It adds:

- `examples/agentic-action-evidence-event.high-impact.json`
- validation coverage for the new example in `tools/validate_evidence_schema.py`

The example demonstrates a high-impact agentic action with:

- high-impact action classification
- action-bound authorization decision artifact
- human approval
- input influence assessment
- correlation and trace IDs
- tamper-evident evidence references
- high-impact profile metadata in `extensions`

## Rationale

Post-v0.2.0 public review feedback identified the need to make Evidence Event Schema profiles more concrete through examples.

This PR adds a schema-valid high-impact example without changing the JSON Schema itself.

## Validation

- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`

## Related issue

Related to #44