### PR TITLE
Link evidence profiles to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │   ├── agentic-action-evidence-event.json
 │   ├── agentic-action-evidence-event.minimal.json
 │   ├── agentic-action-evidence-event.valid.json
+│   ├── agentic-action-evidence-event.high-impact.json
+│   ├── agentic-action-evidence-event.audit-grade.json
 │   ├── agentic-action-evidence-event.invalid.json
 │   └── attack-control-mapping.md
 ├── tools/

--- a/docs/en/14-evidence-event-schema.md
+++ b/docs/en/14-evidence-event-schema.md
@@ -300,6 +300,21 @@ A valid evidence event is not automatically sufficient for every assurance use c
 
 Implementations should select an evidence profile based on action impact, regulatory context, audit needs, and operational risk.
 
+### Profile Examples
+
+The examples below illustrate different Evidence Event Schema usage levels.
+
+| Profile | Example | Purpose |
+|---|---|---|
+| Minimal | [`agentic-action-evidence-event.minimal.json`](../../examples/agentic-action-evidence-event.minimal.json) | Shows the minimum structurally valid evidence event. |
+| General valid example | [`agentic-action-evidence-event.valid.json`](../../examples/agentic-action-evidence-event.valid.json) | Shows a broader valid event with optional sections. |
+| High-Impact | [`agentic-action-evidence-event.high-impact.json`](../../examples/agentic-action-evidence-event.high-impact.json) | Demonstrates high-impact action evidence with authorization artifact, approval, input influence assessment, and traceability. |
+| Audit-Grade | [`agentic-action-evidence-event.audit-grade.json`](../../examples/agentic-action-evidence-event.audit-grade.json) | Demonstrates stronger integrity, provenance, retention, reviewability, and profile metadata through schema-valid extensions. |
+
+These examples are illustrative profiles, not separate certification levels.
+
+Schema validation confirms structural validity only. Evidence profile strength depends on the trustworthiness of the components that generated, protected, correlated, and retained the evidence.
+
 ### Minimal Evidence Profile
 
 The Minimal Evidence Profile is intended for pilots, prototypes, internal reviews, and low-to-medium impact agentic actions.


### PR DESCRIPTION
## Summary

This PR links Evidence Event Schema profiles to their corresponding examples.

It updates:

- `README.md`
- `docs/en/14-evidence-event-schema.md`

The update makes the following examples easier to find:

- `examples/agentic-action-evidence-event.minimal.json`
- `examples/agentic-action-evidence-event.valid.json`
- `examples/agentic-action-evidence-event.high-impact.json`
- `examples/agentic-action-evidence-event.audit-grade.json`

It also clarifies that these examples are illustrative profiles, not certification levels, and that schema validation confirms structural validity only.

## Rationale

Recent v0.2.x updates added High-Impact and Audit-Grade Evidence Event Schema examples.

This PR improves discoverability by linking the Evidence Event Schema profile guidance to the concrete examples.

## Validation

- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`

## Related issue

Related to #44 