### PR TITLE
Clarify existing enforcement implementation framing

### DIFF
--- a/docs/en/13-one-page-overview.md
+++ b/docs/en/13-one-page-overview.md
@@ -98,6 +98,21 @@ AAEF is a framework for reducing, constraining, evidencing, and reviewing agenti
 
 It is not a magic safety layer.
 
+## Implementation Framing
+
+AAEF does not require replacing existing identity, authorization, runtime isolation, or enforcement mechanisms.
+
+It can be implemented using existing mechanisms such as OS users, service accounts, workload identities, IAM, API gateways, policy engines, workflow runners, containers, serverless functions, CLI wrappers, backend services, and audit pipelines.
+
+AAEF focuses on the assurance requirement:
+
+- the model may propose an action,
+- the proposed action should not be treated as authority by itself,
+- high-impact execution should pass through an authorization or enforcement boundary,
+- and evidence should link the proposed action, principal, authorization or enforcement decision, dispatched operation, executed effect, and result.
+
+In short, AAEF is not a new authorization stack. It is a framework for making agentic action authority, enforcement, and evidence boundaries explicit and reviewable.
+
 ## How to Read This Repository
 
 Start here:

--- a/docs/en/17-reference-architecture.md
+++ b/docs/en/17-reference-architecture.md
@@ -553,6 +553,31 @@ AAEF does not require a specific cross-domain credential technology at this stag
 
 ## Implementation Neutrality
 
+AAEF does not require a new tool runtime, identity system, authorization stack, or dispatcher.
+
+The reference architecture can be implemented using existing enforcement mechanisms, including:
+
+- operating system users or Unix UIDs,
+- service accounts,
+- cloud workload identities,
+- enterprise IAM identities,
+- API gateways,
+- IAM policy enforcement,
+- OPA, Cedar, or similar policy engines,
+- workflow runners,
+- container or serverless isolation boundaries,
+- CLI wrappers,
+- backend service enforcement layers,
+- and existing audit or evidence pipelines.
+
+Pseudocode such as `dispatch_tool(tool_call)` and schema fields such as `principal` are abstract representations of the control boundary and evidence model. They are not intended to require a new tool execution platform or a new identity model.
+
+In a concrete implementation, the principal may be an existing user, service account, GitHub Actions actor, workload identity, Unix UID, or enterprise IAM subject.
+
+The key AAEF requirement is not the specific mechanism. The key requirement is that a model-generated action is treated as a proposed action, not authority by itself.
+
+For high-impact actions, the implementation should make the boundary between proposed action, permitted action, dispatched operation, executed effect, and recorded evidence explicit and reviewable.
+
 AAEF does not require:
 
 - a specific LLM,


### PR DESCRIPTION
## Summary

This PR clarifies that AAEF does not require a new tool runtime, identity system, authorization stack, or dispatcher.

It updates:

- `docs/en/13-one-page-overview.md`
- `docs/en/17-reference-architecture.md`

The added guidance explains that AAEF can be implemented using existing mechanisms such as:

- OS users or Unix UIDs
- service accounts
- cloud workload identities
- enterprise IAM identities
- API gateways
- IAM policy enforcement
- OPA, Cedar, or similar policy engines
- workflow runners
- container or serverless isolation boundaries
- CLI wrappers
- backend service enforcement layers
- existing audit or evidence pipelines

## Rationale

External feedback noted that pseudocode such as `dispatch_tool(tool_call)` and schema fields such as `principal` could be misread as requiring a new tool execution platform, identity model, or authorization system.

This PR clarifies that those are abstract representations of the control boundary and evidence model.

AAEF’s requirement is the assurance boundary: a model-generated action is a proposed action, not authority by itself. For high-impact actions, the boundary between proposed action, permitted action, dispatched operation, executed effect, and recorded evidence should be explicit and reviewable.

## Validation

- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`