### PR TITLE
Add high-impact action review surface guidance

### DIFF
--- a/docs/en/12-assessment-quick-start.md
+++ b/docs/en/12-assessment-quick-start.md
@@ -286,6 +286,44 @@ For high-impact actions, assessors should require action-bound evidence linking:
 
 If these links are missing or inconsistent, the assessment should record a finding even if the system produced structurally valid logs or schema-valid evidence events.
 
+### Reviewing High-Impact Action Review Surfaces
+
+For high-impact actions, assessors should review whether the approval or review surface presented enough information for meaningful review.
+
+A review surface may be a web UI, CLI confirmation prompt, approval workflow, ticket, change request, policy review screen, or another mechanism.
+
+Assessors should check whether the review surface showed or linked to:
+
+- the principal,
+- the agent or agent instance,
+- the canonical action,
+- the action type,
+- the target resource,
+- the tool or backend operation,
+- the authority scope,
+- the expected external effect,
+- the risk level or high-impact category,
+- the applicable policy decision,
+- any required approval or override reason,
+- the action or argument digest,
+- the expiration or revocation state,
+- and the evidence reference or correlation ID.
+
+For high-impact actions, approval should be bound to the canonical action that is actually dispatched or executed.
+
+A review surface that presents only a human-readable summary should be treated as weak evidence if the summary is not linked to the canonical action, tool operation, resource, authority scope, and action or argument digest.
+
+If the approved action and executed action cannot be correlated, assessors should record a finding even if an approval record exists.
+
+Assessment should consider whether the system can demonstrate that:
+
+- the approver reviewed the same action that was authorized,
+- the authorized action was the same action that was dispatched,
+- the dispatched operation was the same operation executed by the backend,
+- and the resulting evidence event links the approval, dispatch, execution, and result.
+
+Missing or inconsistent review-surface evidence may indicate approval laundering, payload substitution, replayed authorization artifacts, or weak approval assurance.
+
 ## Assessment Worksheet Columns
 
 The worksheet includes the following columns:

--- a/docs/en/17-reference-architecture.md
+++ b/docs/en/17-reference-architecture.md
@@ -447,6 +447,39 @@ Relevant controls:
 - `AAEF-HUM-03`
 - `AAEF-HUM-04`
 
+### High-Impact Action Review Surface
+
+AAEF does not prescribe a specific user interface for human approval or review.
+
+A review surface may be a web UI, CLI confirmation prompt, approval workflow, ticket, change request, policy review screen, or another mechanism that presents a high-impact action for review before execution.
+
+For high-impact actions, the review surface should make the reviewed action clear enough for the approver or reviewer to understand what is being authorized.
+
+Where applicable, the review surface should expose or reference:
+
+- the principal,
+- the agent or agent instance,
+- the canonical action,
+- the action type,
+- the target resource,
+- the tool or backend operation,
+- the authority scope,
+- the expected external effect,
+- the risk level or high-impact category,
+- the applicable policy decision,
+- any required approval or override reason,
+- the action or argument digest,
+- the expiration or revocation state,
+- and the evidence reference or correlation ID.
+
+The approval should be bound to the canonical action that is actually dispatched or executed.
+
+A human-readable summary alone is not sufficient if the executed action can differ from what the approver reviewed.
+
+If the reviewed action, approved action, dispatched operation, and executed backend effect are not bound together, the system may be vulnerable to approval laundering, payload substitution, replayed authorization artifacts, or action digest mismatch.
+
+AAEF does not require a particular review UI implementation. However, high-impact action review surfaces should make the boundary between proposed action, permitted action, dispatched operation, executed effect, and recorded evidence visible enough to support meaningful approval and later review.
+
 ## Incident Response and Isolation
 
 Incident response may update revocation state, freeze authority, isolate agents, block tools, or trigger reconstruction.


### PR DESCRIPTION
## Summary

This PR adds guidance for high-impact action review surfaces.

It updates:

- `docs/en/17-reference-architecture.md`
- `docs/en/12-assessment-quick-start.md`

The added guidance clarifies that AAEF does not prescribe a specific review UI, but high-impact action review surfaces should make the reviewed action clear enough to support meaningful approval and later review.

A review surface may be a web UI, CLI confirmation prompt, approval workflow, ticket, change request, policy review screen, or another mechanism.

## Rationale

Recent feedback noted that the trusted side of an agentic action boundary may include review tooling that helps a user or approver understand what an action or command is likely to do before it crosses the enforcement boundary.

This PR clarifies what a high-impact action review surface should show or reference, including:

- principal
- agent or agent instance
- canonical action
- action type
- target resource
- tool or backend operation
- authority scope
- expected external effect
- risk level or high-impact category
- applicable policy decision
- required approval or override reason
- action or argument digest
- expiration or revocation state
- evidence reference or correlation ID

It also clarifies that approval should be bound to the canonical action that is actually dispatched or executed.

## Validation

- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`

## Related issues

Related to #27  
Related to #46