### PR TITLE
Align repository status for v0.2.x refinements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+# Changelog
+
+## Unreleased / v0.2.1 Public Review Refinement
+
+This section tracks post-v0.2.0 public review refinements currently merged into `main`.
+
+### Added
+
+- Added Evidence Event Schema profile guidance for Minimal, High-Impact, Audit-Grade, Non-Execution, and Override / Break-Glass evidence profiles.
+- Added High-Impact and Audit-Grade Evidence Event examples.
+- Added validation coverage for High-Impact and Audit-Grade Evidence Event examples.
+- Added Evidence Quality Gate guidance for high-impact actions.
+- Added weak and adversarial evidence examples for high-impact action assessment.
+- Added Open Research Questions for agentic action assurance.
+- Added high-impact action review surface guidance.
+
+### Changed
+
+- Improved README onboarding and role-based reading paths.
+- Strengthened Trusted Control Boundary and Tool Dispatch Enforcement Point guidance.
+- Clarified evidence assertion sources and input influence assessment.
+- Clarified that AAEF can be implemented using existing identity, authorization, runtime isolation, enforcement, and audit mechanisms.
+- Linked Evidence Event Schema profiles to concrete examples.
+- Aligned the assessment worksheet with the control catalog.
+- Renamed worksheet `Maturity` to `Requirement Level`.
+
+### Tooling
+
+- Added assessment worksheet validation.
+- Expanded evidence schema validation to include High-Impact and Audit-Grade examples.
+
+### Notes
+
+- These refinements do not create a certification scheme or claim complete mitigation.
+- The latest tagged public review baseline remains v0.2.0 until a v0.2.1 release is created.
+
 ## v0.2.0 Public Review Draft - 2026-04-26
 
 - Added preliminary OWASP Agentic Top 10 2026 mapping.
@@ -32,8 +68,6 @@
 - Added translation disclaimer and language links to the main README.
 - Clarified that the English README and `docs/en/` are authoritative.
 - Added a translation feedback issue template.
-
-# Changelog
 
 ## v0.1 Public Review Draft — revised pre-publication package
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ AAEF is intended for:
 
 ## Document Status
 
-**AAEF v0.2.0 Public Review Draft** is the current public review draft baseline.
+**AAEF v0.2.0 Public Review Draft** is the latest tagged public review draft baseline.
+
+The `main` branch currently includes post-v0.2.0 public review refinements for Evidence Event Schema profiles, Evidence Quality Gate guidance, assertion source and input influence assessment, High-Impact and Audit-Grade evidence examples, weak and adversarial evidence examples, existing enforcement implementation framing, high-impact action review surfaces, and Open Research Questions.
+
+These post-v0.2.0 refinements are candidates for a future v0.2.1 Public Review Refinement release.
 
 Earlier v0.1.x releases remain available as prior public review baselines.
 
@@ -197,7 +201,8 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │       ├── 15-v02-control-expansion-notes.md
 │       ├── 16-assurance-model.md
 │       ├── 17-reference-architecture.md
-│       └── 18-v020-release-preparation-checklist.md
+│       ├── 18-v020-release-preparation-checklist.md
+│       └── 19-open-research-questions.md
 ├── assessment/
 │   └── aaef-assessment-worksheet-v0.2-draft.csv
 ├── assets/
@@ -219,6 +224,7 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │   ├── agentic-action-evidence-event.invalid.json
 │   └── attack-control-mapping.md
 ├── tools/
+│   ├── validate_assessment_worksheet.py
 │   ├── validate_control_catalog.py
 │   └── validate_evidence_schema.py
 └── .github/


### PR DESCRIPTION
## Summary

This PR aligns the repository status documentation with the post-v0.2.0 public review refinements currently merged into `main`.

It updates:

- `README.md`
- `CHANGELOG.md`

The update clarifies that:

- v0.2.0 remains the latest tagged public review draft baseline
- `main` now includes post-v0.2.0 refinements
- those refinements are candidates for a future v0.2.1 Public Review Refinement release

It also updates the repository structure in the README to include:

- `docs/en/19-open-research-questions.md`
- `tools/validate_assessment_worksheet.py`

## Rationale

Since v0.2.0, several public review refinements have been merged, including Evidence Event Schema profiles, High-Impact and Audit-Grade examples, Evidence Quality Gate guidance, weak/adversarial evidence examples, Open Research Questions, implementation framing clarification, and high-impact action review surface guidance.

This PR keeps the repository status and changelog aligned with the current state of `main` before deciding whether to create a v0.2.1 release.

## Validation

- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`