### PR TITLE
Organize release preparation artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The v0.3.0 Public Review Draft includes:
 - Action Sequence Monitoring and Task Splitting guidance,
 - Assessment Automation and Human Review Classification guidance,
 - Infrastructure and SIEM Evidence Integration guidance,
-- and v0.3.0 Release Preparation Checklist.
+- and historical release preparation records under `docs/en/release/`.
 
 AAEF v0.3.0 remains a public review draft. It is not a certification scheme, formal standard, or claim of complete mitigation.
 
@@ -204,13 +204,14 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │       ├── 15-v02-control-expansion-notes.md
 │       ├── 16-assurance-model.md
 │       ├── 17-reference-architecture.md
-│       ├── 18-v020-release-preparation-checklist.md
 │       ├── 19-open-research-questions.md
 │       ├── 20-assessment-profiles.md
 │       ├── 21-action-sequence-monitoring.md
 │       ├── 22-assessment-automation-and-human-review.md
 │       ├── 23-infrastructure-siem-evidence-integration.md
-│       └── 24-v030-release-preparation-checklist.md
+│       └── release/
+│           ├── v0.2.0-preparation-checklist.md
+│           └── v0.3.0-preparation-checklist.md
 ├── assessment/
 │   ├── aaef-assessment-profiles-v0.3-draft.csv
 │   └── aaef-assessment-worksheet-v0.2-draft.csv

--- a/docs/en/release/v0.2.0-preparation-checklist.md
+++ b/docs/en/release/v0.2.0-preparation-checklist.md
@@ -1,4 +1,10 @@
-# 18. v0.2.0 Release Preparation Checklist
+# v0.2.0 Release Preparation Checklist
+
+> Status: Historical release preparation artifact.
+>
+> This document records the release preparation process for a prior public review release.
+> It is retained for transparency and maintenance continuity.
+> It should not be read as the current project status.
 
 ## Status
 

--- a/docs/en/release/v0.3.0-preparation-checklist.md
+++ b/docs/en/release/v0.3.0-preparation-checklist.md
@@ -1,4 +1,10 @@
-# 24. v0.3.0 Release Preparation Checklist
+# v0.3.0 Release Preparation Checklist
+
+> Status: Completed historical release preparation artifact.
+>
+> The v0.3.0 tag and GitHub Release have been published.
+> This document is retained for transparency and maintenance continuity.
+> It should not be read as an open release blocker list.
 
 This document is a release preparation checklist for the AAEF v0.3.0 public review release.
 
@@ -73,7 +79,7 @@ They do not constitute a security assessment, audit opinion, or implementation c
 Run:
 
     git diff --check
-    git ls-files --eol README.md CHANGELOG.md docs/en/13-one-page-overview.md docs/en/24-v030-release-preparation-checklist.md
+    git ls-files --eol README.md CHANGELOG.md docs/en/13-one-page-overview.md docs/en/release/v0.3.0-preparation-checklist.md
 
 The expected repository convention is LF line endings for text files.
 


### PR DESCRIPTION
## Summary

This PR moves release preparation checklists out of the main `docs/en` numbered document sequence and into a dedicated release artifact directory.

Moved:

- `docs/en/18-v020-release-preparation-checklist.md`
  - to `docs/en/release/v0.2.0-preparation-checklist.md`
- `docs/en/24-v030-release-preparation-checklist.md`
  - to `docs/en/release/v0.3.0-preparation-checklist.md`

It also updates the README repository tree and clarifies that these files are historical release preparation artifacts, not current project blocker lists.

## Rationale

Release preparation checklists are useful to keep public for transparency and maintenance continuity, but they should not be confused with the main framework documents.

This PR separates release process records from the main numbered documentation sequence.

## Notes

- The v0.2.0 checklist is marked as a historical release preparation artifact.
- The v0.3.0 checklist is marked as a completed historical release preparation artifact.
- The v0.3.0 tag and GitHub Release remain unchanged.
- This is a post-release cleanup change on `main`, not a change to the `v0.3.0` release tag.

## Validation

Automated repository validation completed.

These checks validate structural consistency of the assessment profile mapping, assessment worksheet, control catalog, and evidence schema examples. They do not constitute a security assessment, audit opinion, or implementation conformance claim.

- [x] `python tools/validate_assessment_profiles.py`
- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`