### PR TITLE
Clarify current version references

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - family-names: "Horishita"
     given-names: "Kazuma"
     affiliation: "Independent Security Consultant"
-version: "0.2.1-public-review-refinement"
+version: "0.3.0-public-review-draft"
 date-released: "2026-04-27"
 license: "CC-BY-4.0"
 repository-code: "https://github.com/mkz0010/agentic-authority-evidence-framework"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Current catalog file:
 
 - `controls/aaef-controls-v0.1.csv`
 
-The file name is retained for continuity in the v0.2.x public review series. The catalog contains the current v0.2.x public review control set.
+The file name is retained for continuity. The catalog remains the current machine-readable control source of truth unless superseded by a later catalog file.
 
 The Markdown control list in `docs/en/07-control-requirements.md` is maintained for readability and must remain consistent with the CSV catalog. This repository includes a validation script and GitHub Actions workflow to detect control ID drift.
 

--- a/docs/en/14-evidence-event-schema.md
+++ b/docs/en/14-evidence-event-schema.md
@@ -178,9 +178,9 @@ That example demonstrated the concept.
 This schema turns the evidence event into a structured draft format that can be validated and reviewed.
 
 
-## v0.2 Draft Expansion Sections
+## Evidence Event Expansion Sections
 
-The current v0.2 draft schema includes optional sections and objects for recently added control areas.
+The evidence event schema includes optional sections and objects introduced during the v0.2 public review expansion.
 
 ### Authorization Decision Artifact
 


### PR DESCRIPTION
## Summary

This PR clarifies version-related references after the v0.3.0 Public Review Draft release.

It updates:

- `README.md`
- `docs/en/14-evidence-event-schema.md`
- `CITATION.cff`

## Changes

- Clarifies that `controls/aaef-controls-v0.1.csv` remains the current machine-readable control source of truth unless superseded by a later catalog file.
- Updates the Evidence Event Schema section title and wording so v0.2-era schema expansion language is no longer described as the current v0.2 draft.
- Updates `CITATION.cff` from `0.2.1-public-review-refinement` to `0.3.0-public-review-draft`.

## Notes

- Historical v0.1.x and v0.2.x references remain where they describe prior releases, historical artifacts, or file naming continuity.
- The v0.3.0 tag and GitHub Release remain unchanged.
- This PR is part of the v0.3.1 maintenance cycle.

## Validation

Automated repository validation completed.

These checks validate structural consistency of the assessment profile mapping, assessment worksheet, control catalog, and evidence schema examples. They do not constitute a security assessment, audit opinion, or implementation conformance claim.

- [x] `python tools/validate_assessment_profiles.py`
- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_evidence_schema.py`