### PR TITLE
Remove trailing whitespace from v0.5.0 planning overview

### DIFF
--- a/docs/en/33-v050-planning-overview.md
+++ b/docs/en/33-v050-planning-overview.md
@@ -1,7 +1,7 @@
 # v0.5.0 Planning Overview
 
-**Status:** v0.5.0 planning overview  
-**AAEF baseline:** v0.4.1 Public Review Draft  
+**Status:** v0.5.0 planning overview
+**AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Planning document for the next major public review design cycle
 
 ## Purpose


### PR DESCRIPTION
## Summary

This PR removes trailing whitespace from `docs/en/33-v050-planning-overview.md`.

No content changes are intended.

## Validation

- `git diff --check`