### PR TITLE
Update v0.5.0 planning overview examples

### DIFF
--- a/docs/en/33-v050-planning-overview.md
+++ b/docs/en/33-v050-planning-overview.md
@@ -225,3 +225,9 @@ A conservative sequence is:
 | #21 | Authority Denial and Reauthorization Flow | Concept note added; follow-up control, testing, and schema decisions remain. |
 
 Additional v0.5.x topics may include approval quality, tamper-evident evidence storage, and risk-proportional evidence overhead.
+## Planning Examples
+
+The following non-normative example documents illustrate how selected v0.5.0 planning concepts may be reviewed in practice.
+
+- Approval evidence examples: `docs/en/40-approval-evidence-examples.md`
+- Non-execution and reauthorization examples: `docs/en/41-non-execution-reauthorization-examples.md`


### PR DESCRIPTION
## Summary

This PR updates the v0.5.0 Planning Overview to reference the non-normative example documents added during the current planning cycle.

Added references:

- `docs/en/40-approval-evidence-examples.md`
- `docs/en/41-non-execution-reauthorization-examples.md`

This improves discoverability from the v0.5.0 planning overview without changing the Evidence Event Schema, control catalog, testing procedures, or assessment worksheet.

## Validation

- `python tools/validate_testing_procedures.py`
- `python tools/validate_external_mappings.py`
- `python tools/validate_assessment_profiles.py`
- `python tools/validate_assessment_worksheet.py`
- `python tools/validate_control_catalog.py`
- `python tools/validate_evidence_schema.py`

## Issue

Supports #6 and #21.