### PR TITLE
Update v0.5.0 planning index for authority examples

### DIFF
--- a/docs/en/33-v050-planning-overview.md
+++ b/docs/en/33-v050-planning-overview.md
@@ -266,6 +266,8 @@ The v0.5.0 planning materials are intended to be read in the following order.
 | `docs/en/41-non-execution-reauthorization-examples.md` | Denial, deferral, safe termination, retry, task splitting, and reauthorization examples. |
 | `docs/en/42-tamper-evident-evidence-examples.md` | Tamper-evident, independently corroborated, replay, omission, and integrity verification examples. |
 | `docs/en/44-evidence-depth-examples.md` | E3, E4, and E5 evidence depth examples. |
+| `docs/en/45-principal-context-degradation-examples.md` | Principal Context Degradation examples for freshness, drift, reconfirmation, denial, and evidence review. |
+| `docs/en/46-cross-agent-authority-examples.md` | Cross-agent and cross-domain authority examples for authority assertions, delegation lineage, receiving-side validation, and evidence limitations. |
 
 These documents are non-normative planning materials unless otherwise stated. They are intended to support discussion before future schema, control, testing, or assessment changes are adopted.
 
@@ -275,8 +277,8 @@ The following table summarizes selected v0.5.0 planning threads and their curren
 
 | Issue / Thread | Area | Completed Planning Work | Remaining Planning Work |
 | --- | --- | --- | --- |
-| #2 | Principal Context Degradation | Concept note added; planning definitions and related control language strengthened in the v0.5.0 planning cycle. | Schema decisions, assessment guidance, and additional negative tests remain. |
-| #3 | Cross-Agent and Cross-Domain Authority | Concept note added; authority assertion planning profile added; cross-agent authority lineage strengthened. | Schema decisions, assessment guidance, and additional delegation or lineage negative tests remain. |
+| #2 | Principal Context Degradation | Concept note added; planning definitions and related control language strengthened; Principal Context Degradation examples added. | JSON examples, schema field decisions, freshness thresholds, reconfirmation assessment guidance, and stale context negative tests remain. |
+| #3 | Cross-Agent and Cross-Domain Authority | Concept note added; authority assertion planning profile added; cross-agent authority lineage strengthened; cross-agent authority examples added. | JSON examples, authority assertion schema field decisions, receiving-side validation guidance, evidence limitation fields, and stale or replayed assertion negative tests remain. |
 | #6 | Approval quality and approval fatigue | Approval quality concept added; `AAEF-AUZ-03`, `AAEF-HUM-01`, and `AAEF-HUM-02` strengthened; approval evidence examples added. | Approval quality metrics, approval fatigue assessment guidance, approval laundering negative tests, and potential dedicated approval quality control decisions remain. |
 | #19 | Tamper-evident evidence storage | Tamper-evident evidence storage profile added; `AAEF-EVD-04` strengthened; tamper-evident evidence examples added. | Evidence integrity schema field decisions, negative tests for tampering and replay, and incident-response evidence preservation guidance remain. |
 | #20 | Risk-proportional evidence depth | Risk-proportional evidence profile added; assessment guidance added; evidence depth field candidates added; evidence depth examples added. | Schema adoption decisions for `evidence_depth_level`, required depth by action class, assessment profile integration, and JSON examples remain. |


### PR DESCRIPTION
## Summary

This PR updates the v0.5.0 Planning Overview after the Principal Context Degradation and cross-agent authority example additions.

It updates:

- the current planning status rows for #2 and #3,
- the v0.5.0 Planning Document Index to include:
  - `docs/en/45-principal-context-degradation-examples.md`
  - `docs/en/46-cross-agent-authority-examples.md`

This improves discoverability and keeps the planning overview aligned with the current v0.5.0 planning document set.

This PR does not change the Evidence Event Schema, control catalog, testing procedures, or assessment worksheet.

Updated file:

- `docs/en/33-v050-planning-overview.md`

## Validation

- `python tools/validate_testing_procedures.py`
- `python tools/validate_external_mappings.py`
- `python tools/validate_assessment_profiles.py`
- `python tools/validate_assessment_worksheet.py`
- `python tools/validate_control_catalog.py`
- `python tools/validate_evidence_schema.py`