### PR TITLE
Fix v0.4.1 documentation consistency issues

### DIFF
--- a/.github/workflows/validate-aaef-artifacts.yml
+++ b/.github/workflows/validate-aaef-artifacts.yml
@@ -1,6 +1,7 @@
 name: Validate AAEF Artifacts
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:
@@ -12,7 +13,8 @@ permissions:
 jobs:
   validate-aaef-artifacts:
     name: Validate AAEF artifacts
-    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 This maintenance release refines the v0.4.0 Public Review Draft based on post-release review work.
 
+Additional documentation consistency fixes:
+- Added missing human-readable control requirement sections for `AAEF-HUM-03` and `AAEF-HUM-04`.
+- Updated One-page Overview references from v0.2-specific wording to current public review support artifacts.
+- Updated Korean and Simplified Chinese README document status and citation text to v0.4.1.
+- Updated README repository structure to include current v0.5.0 planning documents and mapping files.
+
 ### Changed
 
 - Refined control-specific testing procedure criteria across all 44 controls.

--- a/README.ko.md
+++ b/README.ko.md
@@ -81,13 +81,13 @@ AAEF는 다음 독자를 대상으로 합니다.
 
 ## 문서 상태
 
-**AAEF v0.4.0 Public Review Draft** 는 현재 공개 검토 baseline 입니다.
+**AAEF v0.4.1 Public Review Draft** 는 현재 공개 검토 baseline 입니다.
 
-AAEF v0.4.0은 v0.3.x baseline을 확장하여 agentic AI action assurance를 enterprise assessment 및 audit support에서 더 쉽게 사용할 수 있도록 guidance를 추가합니다.
+AAEF v0.4.1은 v0.4.0에 대한 maintenance and refinement release 입니다. v0.4.0의 enterprise assessment usability baseline을 유지하면서 testing criteria 및 external framework mappings에 대한 post-release refinements를 반영합니다.
 
 이전 v0.3.x, v0.2.x, v0.1.x releases 는 prior public review baselines 로 계속 참조할 수 있습니다.
 
-AAEF v0.4.0에 추가된 주요 요소:
+AAEF v0.4.1에 포함된 주요 요소:
 
 - control catalog versioning and change impact guidance
 - measurable testing procedures and pass criteria
@@ -97,8 +97,10 @@ AAEF v0.4.0에 추가된 주요 요소:
 - external framework mapping methodology
 - initial conservative external framework mapping draft
 - validation for testing procedures and external mappings
+- refined control-specific testing procedure pass criteria
+- updated conservative external framework mappings, including NIST AI RMF / GenAI Profile, ISO/IEC 42001 feasibility, and CSA Agentic Trust Framework mapping
 
-AAEF v0.4.0은 공개 검토 초안입니다. 인증 체계, 공식 표준, implementation conformance claim, audit opinion, compliance equivalence 또는 완전한 완화 주장을 의미하지 않습니다.
+AAEF v0.4.1은 공개 검토 초안입니다. 인증 체계, 공식 표준, implementation conformance claim, audit opinion, compliance equivalence 또는 완전한 완화 주장을 의미하지 않습니다.
 
 Issues 및 Pull Requests를 통한 피드백을 환영합니다.
 
@@ -118,7 +120,7 @@ AAEF를 처음 읽는 경우, 영어 문서 기준으로 다음 순서를 권장
 
 이 작업을 참조하는 경우 다음과 같이 인용하십시오.
 
-> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.4.0 Public Review Draft, 2026.
+> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.4.1 Public Review Draft, 2026.
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,27 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │       ├── 26-high-impact-audit-grade-prequalification.md
 │       ├── 27-trusted-control-boundary-integrity.md
 │       ├── 28-external-framework-mapping-methodology.md
+│       ├── 29-iso-iec-42001-feasibility.md
+│       ├── 30-principal-context-degradation.md
+│       ├── 31-cross-agent-cross-domain-authority.md
+│       ├── 32-authority-denial-reauthorization-flow.md
+│       ├── 33-v050-planning-overview.md
+│       ├── 34-v050-control-design-options.md
+│       ├── 35-authority-assertion-profile.md
+│       ├── 36-risk-proportional-evidence-profile.md
+│       ├── 37-tamper-evident-evidence-storage.md
+│       ├── 38-v050-evidence-schema-field-candidates.md
+│       ├── 39-approval-quality-approval-fatigue.md
+│       ├── 40-approval-evidence-examples.md
+│       ├── 41-non-execution-reauthorization-examples.md
+│       ├── 42-tamper-evident-evidence-examples.md
+│       ├── 43-risk-proportional-evidence-assessment-guidance.md
+│       ├── 44-evidence-depth-examples.md
+│       ├── 45-principal-context-degradation-examples.md
+│       ├── 46-cross-agent-authority-examples.md
+│       ├── 47-approval-quality-assessment-guidance.md
+│       ├── 48-non-execution-reauthorization-negative-tests.md
+│       ├── 49-tamper-evident-evidence-negative-tests.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md
@@ -242,6 +263,8 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 │   └── aaef-reference-architecture.mmd
 ├── mappings/
 │   ├── aaef-external-framework-mapping-v0.4-draft.csv
+│   ├── csa-agentic-trust-framework.md
+│   ├── nist-ai-rmf-genai-profile.md
 │   ├── owasp-agentic-top10-2026.md
 │   ├── threat-control-assurance-mapping.md
 │   └── threat-control-assurance-mapping-v0.2-draft.csv

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,13 +81,13 @@ AAEF 面向以下读者：
 
 ## 文档状态
 
-**AAEF v0.4.0 Public Review Draft** 是当前公开评审 baseline。
+**AAEF v0.4.1 Public Review Draft** 是当前公开评审 baseline。
 
-AAEF v0.4.0 在 v0.3.x baseline 的基础上增加了 enterprise assessment usability guidance，使 agentic AI action assurance 更容易用于企业评估和审计辅助场景。
+AAEF v0.4.1 是 v0.4.0 的 maintenance and refinement release。它保留 v0.4.0 的 enterprise assessment usability baseline，并纳入对 testing criteria 和 external framework mappings 的 post-release refinements。
 
 此前的 v0.3.x、v0.2.x、v0.1.x releases 仍可作为 prior public review baselines 参考。
 
-AAEF v0.4.0 新增的主要内容包括：
+AAEF v0.4.1 包含的主要内容包括：
 
 - control catalog versioning and change impact guidance
 - measurable testing procedures and pass criteria
@@ -97,8 +97,10 @@ AAEF v0.4.0 新增的主要内容包括：
 - external framework mapping methodology
 - initial conservative external framework mapping draft
 - validation for testing procedures and external mappings
+- refined control-specific testing procedure pass criteria
+- updated conservative external framework mappings, including NIST AI RMF / GenAI Profile, ISO/IEC 42001 feasibility, and CSA Agentic Trust Framework mapping
 
-AAEF v0.4.0 仍是公开评审草案。它不是认证机制、正式标准、implementation conformance claim、audit opinion、compliance equivalence，也不声称能够完全缓解所有风险。
+AAEF v0.4.1 仍是公开评审草案。它不是认证机制、正式标准、implementation conformance claim、audit opinion、compliance equivalence，也不声称能够完全缓解所有风险。
 
 欢迎通过 Issues 和 Pull Requests 提供反馈。
 
@@ -118,7 +120,7 @@ AAEF v0.4.0 仍是公开评审草案。它不是认证机制、正式标准、im
 
 如果引用本项目，请使用以下格式：
 
-> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.4.0 Public Review Draft, 2026.
+> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.4.1 Public Review Draft, 2026.
 
 ## 许可证
 

--- a/docs/en/07-control-requirements.md
+++ b/docs/en/07-control-requirements.md
@@ -479,6 +479,41 @@ A workflow that produces many low-context or repetitive approval prompts may tra
 For the related v0.5.0 planning concept, see `docs/en/39-approval-quality-approval-fatigue.md`.
 
 
+### AAEF-HUM-03: Human override and exceptional intervention shall be recorded as append-only evidence
+
+**Domain:** Human Oversight
+**Requirement:** Systems shall record structured, append-only evidence when a human overrides, interrupts, reverses, extends, or bypasses normal agentic authorization flow for high-impact actions.
+**Objective:** Preserve auditability when exceptional human intervention changes or bypasses normal agentic control flow.
+**Applicability:** High-impact workflows where humans can perform emergency stop, manual reversal, forced continuation, exception handling, temporary authority grant, or privileged intervention.
+**Testing Procedure:** Review override scenarios and verify that override actor, reason, authority, scope, timestamp, linked action, and post-review requirement are recorded without overwriting existing evidence.
+**Evidence Examples:** Override event; linked action ID; override actor ID; override reason; override authority; override scope; timestamp; incident reference; post-review record.
+**Maturity:** Required
+
+**Implementation Note:** Human intervention may be necessary during incidents, safety events, customer-impacting failures, or urgent operational exceptions.
+
+This control does not prohibit override, interruption, reversal, or forced continuation. It requires those interventions to create additional evidence that preserves the original action history, identifies who intervened, explains why normal flow was changed, and links the intervention to the affected action or workflow.
+
+Override evidence should be additive. A human override should not erase the original authorization decision, dispatched action, execution result, denial event, or prior review context.
+
+
+### AAEF-HUM-04: Break-glass authority shall be scoped, time-bound, attributable, and post-reviewed
+
+**Domain:** Human Oversight
+**Requirement:** Systems shall constrain break-glass or emergency authority grants with explicit actor identity, reason, scope, expiration, and post-review requirements.
+**Objective:** Allow emergency intervention without creating unbounded or unevidenced authority expansion.
+**Applicability:** Systems that support break-glass, emergency access, temporary authority expansion, or incident-driven bypass of normal approval flow.
+**Testing Procedure:** Test break-glass flows and verify that emergency authority is scoped, time-bound, attributable, recorded, and subject to post-review.
+**Evidence Examples:** Break-glass grant; actor identity; reason; scope; expiration; approval or incident reference; post-review record; revocation record.
+**Maturity:** Required
+
+**Implementation Note:** Break-glass authority should be treated as controlled emergency authority, not as a permanent alternative authorization path.
+
+A break-glass grant should identify the actor, reason, affected agent or workflow, allowed action scope, expiration, linked incident or approval reference, and required post-review. Emergency authority should expire or be revoked after use, and actions taken under that authority should remain attributable and reconstructable.
+
+This control complements `AAEF-RES-01` and `AAEF-RES-02` by ensuring that emergency authority expansion can later be revoked, reviewed, and distinguished from normal authorization flow.
+
+
+
 ### AAEF-RES-01: Organizations shall be able to revoke agent authority, tool access, credentials, and active delegations
 
 **Domain:** Response and Revocation  

--- a/docs/en/13-one-page-overview.md
+++ b/docs/en/13-one-page-overview.md
@@ -54,15 +54,18 @@ AAEF covers control areas such as:
 - human oversight,
 - response and revocation.
 
-AAEF also includes supporting materials for v0.2 public review:
+AAEF also includes current public review support materials:
 
 - High-Impact Action Taxonomy,
-- Evidence Event JSON Schema,
-- Evidence Schema validation workflow,
+- Evidence Event JSON Schema and validation workflow,
 - OWASP Agentic Top 10 mapping,
 - Assurance Model and Residual Risk Mapping,
-- Assessment Quick Start,
-- Assessment Worksheet.
+- Assessment Quick Start and Assessment Worksheet,
+- Assessment Profiles,
+- Testing Procedures and Pass Criteria,
+- High-Impact and Audit-Grade pre-qualification guidance,
+- Trusted Control Boundary integrity guidance,
+- external framework mapping methodology and conservative mapping drafts.
 
 ## What Counts as High-Impact?
 
@@ -135,14 +138,17 @@ Start here:
 6. `controls/aaef-controls-v0.1.csv`  
    Machine-readable control catalog source.
 
-Then read the v0.2 public review artifacts:
+Then read the current public review support artifacts:
 
 - `docs/en/11-high-impact-action-taxonomy.md`
 - `docs/en/14-evidence-event-schema.md`
-- `docs/en/15-v02-control-expansion-notes.md`
 - `docs/en/16-assurance-model.md`
 - `docs/en/12-assessment-quick-start.md`
+- `docs/en/20-assessment-profiles.md`
+- `docs/en/25-testing-procedures-and-pass-criteria.md`
 - `assessment/aaef-assessment-worksheet-v0.2-draft.csv`
+- `assessment/aaef-assessment-profiles-v0.3-draft.csv`
+- `assessment/aaef-testing-procedures-v0.4-draft.csv`
 
 ## How AAEF Can Be Used
 


### PR DESCRIPTION
## Summary

This PR fixes documentation consistency issues in the v0.4.1 public review draft.

Changes include:

- Add missing human-readable control requirement sections for `AAEF-HUM-03` and `AAEF-HUM-04`
- Align the control catalog and `docs/en/07-control-requirements.md` at 44 controls
- Update stale v0.2 public review wording in the one-page overview
- Update Korean and Simplified Chinese README status text from v0.4.0 to v0.4.1
- Expand the README repository structure to include current v0.5.0 planning documents
- Add a changelog note for the documentation consistency fixes
- Improve the validation workflow with manual dispatch, Ubuntu version pinning, and timeout configuration

## Validation

Validated locally:

```text
OK: 44 assessment profile mapping rows validated.
OK: 44 assessment worksheet rows validated.
OK: 44 controls validated.
OK: 44 testing procedure rows validated.
OK: 10 external framework mapping rows validated.
OK: evidence schema and examples validated.
````

Commands run:

```bash
python tools/validate_assessment_profiles.py
python tools/validate_assessment_worksheet.py
python tools/validate_control_catalog.py
python tools/validate_testing_procedures.py
python tools/validate_external_mappings.py
python tools/validate_evidence_schema.py
```

## Notes

This is a documentation consistency and workflow-hardening update. It does not change the control catalog CSV, evidence schema, assessment profiles, or testing procedure artifacts.