### PR TITLE
Clarify v0.5.0 planning scope and normative boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Clarified that `docs/en/30-49` v0.5.0 planning materials are non-normative unless explicitly incorporated into catalog, schema, assessment, testing, or release artifacts.
+- Clarified the v0.5.0 planning overview by grouping the six planning themes into authority lifecycle and supporting assurance themes.
+- Added missing v0.5.0 planning document index entries for Principal Context Degradation and tamper-evident evidence negative tests.
+- Clarified current-status wording for v0.2-originated documents that remain part of the v0.4.1 Public Review Draft baseline.
+
 ## v0.4.1 Public Review Refinement Release - 2026-04-28
 
 This maintenance release refines the v0.4.0 Public Review Draft based on post-release review work.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ Control catalog versioning and change impact guidance is documented in [`docs/en
 
 The Markdown control list in `docs/en/07-control-requirements.md` is maintained for readability and must remain consistent with the CSV catalog. This repository includes a validation script and GitHub Actions workflow to detect control ID drift.
 
+## Planning Material Boundary
+
+Documents under `docs/en/30-49` are v0.5.0 planning materials. They are non-normative unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
+
+These documents currently remain under `docs/en/` for public review continuity. A future release may move them into a dedicated planning directory if the repository structure is reorganized.
+
 ## Repository Structure
 
 ```text

--- a/docs/en/11-high-impact-action-taxonomy.md
+++ b/docs/en/11-high-impact-action-taxonomy.md
@@ -8,7 +8,7 @@ Machine-readable draft:
 
 - `taxonomies/high-impact-action-taxonomy-v0.2-draft.csv`
 
-This taxonomy is intended for AAEF v0.2.0 discussion and review. It is not a certification scheme, legal standard, or exhaustive list of all high-risk agentic AI actions.
+This taxonomy originated during the AAEF v0.2.0 discussion and review cycle and remains part of the current v0.4.1 Public Review Draft baseline. It is not a certification scheme, legal standard, or exhaustive list of all high-risk agentic AI actions.
 
 ## Machine-Readable CSV
 

--- a/docs/en/12-assessment-quick-start.md
+++ b/docs/en/12-assessment-quick-start.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This document is an initial assessment quick start for AAEF v0.2 public review.
+This document originated as an initial assessment quick start during the AAEF v0.2 public review cycle and remains part of the current v0.4.1 Public Review Draft baseline.
 
 It is intended to help reviewers, implementers, security teams, AI governance teams, and auditors begin using AAEF as an assessment aid.
 

--- a/docs/en/14-evidence-event-schema.md
+++ b/docs/en/14-evidence-event-schema.md
@@ -14,7 +14,7 @@ Examples:
 - `examples/agentic-action-evidence-event.valid.json`
 - `examples/agentic-action-evidence-event.invalid.json`
 
-This schema is intended for AAEF v0.2.0 discussion and review. It is not a certification format and does not guarantee compliance by itself.
+This schema originated during the AAEF v0.2.0 discussion and review cycle and remains part of the current v0.4.1 Public Review Draft baseline. It is not a certification format and does not guarantee compliance by itself.
 
 ## Purpose
 
@@ -180,7 +180,7 @@ This schema turns the evidence event into a structured draft format that can be 
 
 ## Evidence Event Expansion Sections
 
-The evidence event schema includes optional sections and objects introduced during the v0.2 public review expansion.
+The evidence event schema includes optional sections and objects introduced during earlier public review expansion and retained in the current baseline.
 
 ### Authorization Decision Artifact
 

--- a/docs/en/16-assurance-model.md
+++ b/docs/en/16-assurance-model.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This document defines an initial AAEF assurance model for v0.2 public review.
+This document originated as an initial AAEF assurance model during the v0.2 public review cycle and remains part of the current v0.4.1 Public Review Draft baseline.
 
 It is not a certification scheme and does not claim that implementing AAEF controls eliminates agentic AI risk.
 

--- a/docs/en/17-reference-architecture.md
+++ b/docs/en/17-reference-architecture.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This document is a reference architecture for AAEF v0.2 public review.
+This document originated as the AAEF reference architecture during the v0.2 public review cycle and remains part of the current v0.4.1 Public Review Draft baseline.
 
 It is not a required implementation architecture and does not mandate specific vendors, protocols, runtimes, policy engines, databases, or identity systems.
 

--- a/docs/en/30-principal-context-degradation.md
+++ b/docs/en/30-principal-context-degradation.md
@@ -1,8 +1,10 @@
 # Principal Context Degradation
 
-**Status:** v0.5.0 planning concept note
+**Status:** Non-normative v0.5.0 planning concept note
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Issue context:** #2
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/31-cross-agent-cross-domain-authority.md
+++ b/docs/en/31-cross-agent-cross-domain-authority.md
@@ -1,8 +1,10 @@
 # Cross-Agent and Cross-Domain Authority
 
-**Status:** v0.5.0 planning concept note
+**Status:** Non-normative v0.5.0 planning concept note
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Issue context:** #3
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/32-authority-denial-reauthorization-flow.md
+++ b/docs/en/32-authority-denial-reauthorization-flow.md
@@ -1,8 +1,10 @@
 # Authority Denial and Reauthorization Flow
 
-**Status:** v0.5.0 planning concept note
+**Status:** Non-normative v0.5.0 planning concept note
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Issue context:** #21
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/33-v050-planning-overview.md
+++ b/docs/en/33-v050-planning-overview.md
@@ -1,8 +1,10 @@
 # v0.5.0 Planning Overview
 
-**Status:** v0.5.0 planning overview
+**Status:** Non-normative v0.5.0 planning overview
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Planning document for the next major public review design cycle
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 
@@ -18,20 +20,27 @@ For control design tradeoffs before changing the catalog, see `docs/en/34-v050-c
 
 ## v0.5.0 Core Design Themes
 
-The initial v0.5.0 planning work is organized around three related concepts:
+The initial v0.5.0 planning work is organized around six related planning themes.
+
+Core authority lifecycle themes:
 
 1. Principal Context Degradation
 2. Cross-Agent and Cross-Domain Authority
 3. Authority Denial and Reauthorization Flow
+
+Supporting assurance themes:
+
 4. Risk-Proportional Evidence and Performance Overhead
 5. Tamper-Evident Evidence Storage
 6. Approval Quality and Approval Fatigue
 
-Together, these concepts refine AAEF's core claim that model output is not authority.
+Together, these themes refine AAEF's core claim that model output is not authority.
 
 For approval quality and approval fatigue planning, see `docs/en/39-approval-quality-approval-fatigue.md`.
 
-They focus on whether authority remains valid, traceable, bounded, and reviewable across time, delegation, agent boundaries, trust domains, and denial or reauthorization paths.
+The authority lifecycle themes focus on whether authority remains valid, traceable, bounded, and reviewable across time, delegation, agent boundaries, trust domains, and denial or reauthorization paths.
+
+The supporting assurance themes focus on whether evidence depth, evidence integrity, and human approval quality are proportionate to the risk of the action being reviewed.
 
 ## Theme 1: Principal Context Degradation
 
@@ -102,15 +111,18 @@ The main design question is whether AAEF should strengthen guidance for:
 - reauthorization evidence;
 - linkage between denial, escalation, reauthorization, and final execution or non-execution outcomes.
 
-## Relationship Among the Three Themes
+## Relationship Among the Planning Themes
 
 These themes are intentionally connected.
 
-| Theme | Key dependency |
-| --- | --- |
-| Principal Context Degradation | May trigger denial, escalation, or reauthorization when context is stale or ambiguous. |
-| Cross-Agent and Cross-Domain Authority | May cause principal context loss, delegation drift, evidence trust gaps, or revocation propagation gaps. |
-| Authority Denial and Reauthorization Flow | Provides the controlled path when authority is insufficient, degraded, ambiguous, or unverifiable. |
+| Theme | Theme group | Key dependency |
+| --- | --- | --- |
+| Principal Context Degradation | Authority lifecycle | May trigger denial, escalation, or reauthorization when context is stale or ambiguous. |
+| Cross-Agent and Cross-Domain Authority | Authority lifecycle | May cause principal context loss, delegation drift, evidence trust gaps, or revocation propagation gaps. |
+| Authority Denial and Reauthorization Flow | Authority lifecycle | Provides the controlled path when authority is insufficient, degraded, ambiguous, or unverifiable. |
+| Risk-Proportional Evidence and Performance Overhead | Supporting assurance | Helps decide how much evidence depth is justified for a given action, risk level, and operational cost. |
+| Tamper-Evident Evidence Storage | Supporting assurance | Helps preserve evidence integrity when actions, denials, approvals, or reauthorizations must be reviewed later. |
+| Approval Quality and Approval Fatigue | Supporting assurance | Helps determine whether human approval provides meaningful authority rather than blind approval, fatigue-driven approval, or approval laundering. |
 
 A future v0.5.0 design should avoid treating these as isolated features.
 
@@ -119,7 +131,9 @@ For example:
 - degraded principal context in a long-running workflow may require scoped reauthorization;
 - cross-domain authority gaps may require receiving-side denial or external evidence verification;
 - repeated denial in a cross-agent workflow may indicate attempted policy bypass or task splitting;
-- revocation in one domain may require downstream freeze, denial, or residual-risk evidence in another domain.
+- revocation in one domain may require downstream freeze, denial, or residual-risk evidence in another domain;
+- higher-risk reauthorization paths may require stronger evidence depth and tamper-evident preservation;
+- human approval may need additional context, batching limits, or retry-pressure safeguards when an agent repeatedly asks for the same denied action.
 
 ## Candidate v0.5.0 Refinement Areas
 
@@ -239,6 +253,7 @@ The v0.5.0 planning materials are intended to be read in the following order.
 
 | Document | Purpose |
 | --- | --- |
+| `docs/en/30-principal-context-degradation.md` | Principal context degradation, freshness, drift, reconfirmation, and authority sufficiency planning concept. |
 | `docs/en/31-cross-agent-cross-domain-authority.md` | Cross-agent and cross-domain authority planning concept. |
 | `docs/en/32-authority-denial-reauthorization-flow.md` | Authority denial, non-execution, retry, and reauthorization flow planning concept. |
 | `docs/en/39-approval-quality-approval-fatigue.md` | Approval quality, blind approval, approval fatigue, and meaningful human review planning concept. |
@@ -267,6 +282,7 @@ The v0.5.0 planning materials are intended to be read in the following order.
 | `docs/en/41-non-execution-reauthorization-examples.md` | Denial, deferral, safe termination, retry, task splitting, and reauthorization examples. |
 | `docs/en/48-non-execution-reauthorization-negative-tests.md` | Negative test candidates for denial, deferral, freeze, safe termination, retry, task splitting, reauthorization, and selective omission of non-execution evidence. |
 | `docs/en/42-tamper-evident-evidence-examples.md` | Tamper-evident, independently corroborated, replay, omission, and integrity verification examples. |
+| `docs/en/49-tamper-evident-evidence-negative-tests.md` | Negative test candidates for evidence tampering, replay, omission, anchoring gaps, and integrity verification failures. |
 | `docs/en/44-evidence-depth-examples.md` | E3, E4, and E5 evidence depth examples. |
 | `docs/en/45-principal-context-degradation-examples.md` | Principal Context Degradation examples for freshness, drift, reconfirmation, denial, and evidence review. |
 | `docs/en/46-cross-agent-authority-examples.md` | Cross-agent and cross-domain authority examples for authority assertions, delegation lineage, receiving-side validation, and evidence limitations. |

--- a/docs/en/34-v050-control-design-options.md
+++ b/docs/en/34-v050-control-design-options.md
@@ -1,8 +1,10 @@
 # v0.5.0 Control Design Options
 
-**Status:** v0.5.0 planning design note
+**Status:** Non-normative v0.5.0 planning design note
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Control design options before changing the control catalog, evidence schema, assessment worksheet, or testing procedures
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/35-authority-assertion-profile.md
+++ b/docs/en/35-authority-assertion-profile.md
@@ -1,8 +1,10 @@
 # Authority Assertion Profile
 
-**Status:** v0.5.0 planning profile
+**Status:** Non-normative v0.5.0 planning profile
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative planning profile for cross-agent and cross-domain authority assertions
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/36-risk-proportional-evidence-profile.md
+++ b/docs/en/36-risk-proportional-evidence-profile.md
@@ -1,8 +1,10 @@
 # Risk-Proportional Evidence Profile
 
-**Status:** v0.5.0 planning profile
+**Status:** Non-normative v0.5.0 planning profile
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative planning profile for evidence depth, assurance value, and operational overhead
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/37-tamper-evident-evidence-storage.md
+++ b/docs/en/37-tamper-evident-evidence-storage.md
@@ -1,8 +1,10 @@
 # Tamper-Evident Evidence Storage
 
-**Status:** v0.5.0 planning profile
+**Status:** Non-normative v0.5.0 planning profile
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative planning profile for evidence integrity, tamper evidence, and independent verification
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/38-v050-evidence-schema-field-candidates.md
+++ b/docs/en/38-v050-evidence-schema-field-candidates.md
@@ -1,8 +1,10 @@
 # v0.5.0 Evidence Schema Field Candidates
 
-**Status:** v0.5.0 planning note
+**Status:** Non-normative v0.5.0 planning note
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative field candidate inventory before changing the Evidence Event Schema
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/39-approval-quality-approval-fatigue.md
+++ b/docs/en/39-approval-quality-approval-fatigue.md
@@ -1,8 +1,10 @@
 # Approval Quality and Approval Fatigue
 
-**Status:** v0.5.0 planning concept
+**Status:** Non-normative v0.5.0 planning concept
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative planning note for approval quality, approval fatigue, and meaningful human authorization
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/40-approval-evidence-examples.md
+++ b/docs/en/40-approval-evidence-examples.md
@@ -1,8 +1,10 @@
 # Approval Evidence Examples
 
-**Status:** v0.5.0 planning examples
+**Status:** Non-normative v0.5.0 planning examples
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative examples for approval quality, approval evidence, and approval laundering review
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/41-non-execution-reauthorization-examples.md
+++ b/docs/en/41-non-execution-reauthorization-examples.md
@@ -1,8 +1,10 @@
 # Non-Execution and Reauthorization Examples
 
-**Status:** v0.5.0 planning examples
+**Status:** Non-normative v0.5.0 planning examples
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative examples for denial, deferral, safe termination, escalation, freeze, and reauthorization review
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/42-tamper-evident-evidence-examples.md
+++ b/docs/en/42-tamper-evident-evidence-examples.md
@@ -1,8 +1,10 @@
 # Tamper-Evident Evidence Examples
 
-**Status:** v0.5.0 planning examples
+**Status:** Non-normative v0.5.0 planning examples
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative examples for tamper-evident, independently corroborated, and integrity-verifiable evidence review
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/43-risk-proportional-evidence-assessment-guidance.md
+++ b/docs/en/43-risk-proportional-evidence-assessment-guidance.md
@@ -1,8 +1,10 @@
 # Risk-Proportional Evidence Assessment Guidance
 
-**Status:** v0.5.0 planning guidance
+**Status:** Non-normative v0.5.0 planning guidance
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative assessment guidance for evidence depth, assurance value, and operational overhead
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/44-evidence-depth-examples.md
+++ b/docs/en/44-evidence-depth-examples.md
@@ -1,8 +1,10 @@
 # Evidence Depth Examples
 
-**Status:** v0.5.0 planning examples
+**Status:** Non-normative v0.5.0 planning examples
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative examples for E3, E4, and E5 evidence depth assessment
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/45-principal-context-degradation-examples.md
+++ b/docs/en/45-principal-context-degradation-examples.md
@@ -1,8 +1,10 @@
 # Principal Context Degradation Examples
 
-**Status:** v0.5.0 planning examples
+**Status:** Non-normative v0.5.0 planning examples
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative examples for principal context freshness, ambiguity, drift, reconfirmation, denial, and reauthorization review
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/46-cross-agent-authority-examples.md
+++ b/docs/en/46-cross-agent-authority-examples.md
@@ -1,8 +1,10 @@
 # Cross-Agent and Cross-Domain Authority Examples
 
-**Status:** v0.5.0 planning examples
+**Status:** Non-normative v0.5.0 planning examples
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative examples for cross-agent authority, cross-domain authority assertions, delegation lineage, receiving-side validation, and evidence limitations
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/47-approval-quality-assessment-guidance.md
+++ b/docs/en/47-approval-quality-assessment-guidance.md
@@ -1,8 +1,10 @@
 # Approval Quality Assessment Guidance
 
-**Status:** v0.5.0 planning guidance
+**Status:** Non-normative v0.5.0 planning guidance
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative assessment guidance for meaningful approval, blind approval, approval fatigue, approval laundering, retry pressure, and task-splitting review
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/48-non-execution-reauthorization-negative-tests.md
+++ b/docs/en/48-non-execution-reauthorization-negative-tests.md
@@ -1,8 +1,10 @@
 # Non-Execution and Reauthorization Negative Tests
 
-**Status:** v0.5.0 planning negative tests
+**Status:** Non-normative v0.5.0 planning negative tests
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative negative tests for denial, deferral, freeze, safe termination, retry, task splitting, reauthorization, and non-execution evidence review
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 

--- a/docs/en/49-tamper-evident-evidence-negative-tests.md
+++ b/docs/en/49-tamper-evident-evidence-negative-tests.md
@@ -1,8 +1,10 @@
 # Tamper-Evident Evidence Negative Tests
 
-**Status:** v0.5.0 planning negative tests
+**Status:** Non-normative v0.5.0 planning negative tests
 **AAEF baseline:** v0.4.1 Public Review Draft
 **Scope:** Non-normative negative tests for evidence tampering, replay, deletion, truncation, reordering, selective omission, integrity verification, and evidence preservation review
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 ## Purpose
 


### PR DESCRIPTION
## Summary

This PR clarifies the scope and normative boundary of v0.5.0 planning materials.

Changes include:

- Clarify that v0.5.0 planning materials under `docs/en/30-49` are non-normative
- Add planning status notes to v0.5.0 planning documents
- Clarify that planning materials are not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into catalog, schema, assessment, testing, or release artifacts
- Update the v0.5.0 planning overview from the earlier “three concepts” framing to the current six-theme planning structure
- Add a README section explaining the planning material boundary
- Clarify status wording for v0.2-originated documents that remain part of the current v0.4.1 baseline
- Add an Unreleased changelog entry

## Validation

Validated locally:

```text
OK: 44 assessment profile mapping rows validated.
OK: 44 assessment worksheet rows validated.
OK: 44 controls validated.
OK: 44 testing procedure rows validated.
OK: 10 external framework mapping rows validated.
OK: evidence schema and examples validated.
````

Commands run:

```bash
python tools/validate_assessment_profiles.py
python tools/validate_assessment_worksheet.py
python tools/validate_control_catalog.py
python tools/validate_testing_procedures.py
python tools/validate_external_mappings.py
python tools/validate_evidence_schema.py
```

## Impact

This is a documentation clarification update.

It does not change:

* control catalog CSV
* assessment worksheet
* assessment profiles
* testing procedure CSV
* external framework mapping CSV
* evidence schema
* evidence examples
