### PR TITLE
Add v0.5.0 planning incorporation rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Added v0.5.0 planning incorporation rules to clarify when planning concepts become guidance, testing refinements, evidence refinements, existing control refinements, or new controls.
 - Clarified that `docs/en/30-49` v0.5.0 planning materials are non-normative unless explicitly incorporated into catalog, schema, assessment, testing, or release artifacts.
 - Clarified the v0.5.0 planning overview by grouping the six planning themes into authority lifecycle and supporting assurance themes.
 - Added missing v0.5.0 planning document index entries for Principal Context Degradation and tamper-evident evidence negative tests.

--- a/docs/en/33-v050-planning-overview.md
+++ b/docs/en/33-v050-planning-overview.md
@@ -16,7 +16,7 @@ AAEF v0.5.0 planning shifts toward deeper authority semantics for agentic AI sys
 
 This document does not add new controls, schema fields, or assessment requirements by itself. It organizes the main design themes that may later become control, schema, testing, or architecture refinements.
 
-For control design tradeoffs before changing the catalog, see `docs/en/34-v050-control-design-options.md`.
+For control design tradeoffs and incorporation rules before changing the catalog, see `docs/en/34-v050-control-design-options.md`.
 
 ## v0.5.0 Core Design Themes
 

--- a/docs/en/34-v050-control-design-options.md
+++ b/docs/en/34-v050-control-design-options.md
@@ -33,6 +33,58 @@ v0.5.0 control design should follow these principles:
 6. Preserve AAEF's core premise: model output is not authority.
 7. Keep v0.5.0 implementable for real agentic AI systems.
 
+## Normative Incorporation Rules
+
+v0.5.0 planning concepts do not become normative AAEF requirements merely because they are described in planning documents.
+
+A planning concept becomes normative only when it is explicitly incorporated into one or more normative or assessment artifacts, such as:
+
+- the control catalog CSV;
+- the human-readable control requirements;
+- the testing procedures;
+- the assessment worksheet or assessment profiles;
+- the evidence schema or required evidence examples;
+- release notes that explicitly identify the incorporated change.
+
+### Incorporation Outcomes
+
+Each v0.5.0 planning concept should be resolved into one of the following outcomes before release.
+
+| Outcome | Meaning | Required action |
+| --- | --- | --- |
+| Planning only | The concept remains design input for future work. | Keep it marked as non-normative planning material. |
+| Guidance only | The concept informs implementation or assessment interpretation, but does not create a new requirement. | Add or update guidance text without changing control obligations. |
+| Testing refinement | The concept changes how an existing control is tested. | Update testing procedures and validation expectations. |
+| Evidence refinement | The concept requires new or clearer evidence expectations. | Update evidence guidance, examples, or schema candidates as appropriate. |
+| Existing control refinement | The concept strengthens an existing control without creating a new control ID. | Update the relevant control requirement, testing procedure, and assessment artifacts together. |
+| New control | The concept introduces a distinct assessable obligation that does not fit existing controls. | Add a new control ID and update related testing, assessment, mapping, and evidence artifacts. |
+
+### Promotion Criteria
+
+Before a planning concept is promoted into the control catalog or other normative artifacts, it should satisfy the following criteria:
+
+1. **Distinct obligation:** The concept creates a clearly assessable obligation that is not already covered by existing controls.
+2. **Action boundary relevance:** The obligation relates to authorization, execution, evidence, recovery, delegation, principal binding, human approval, or governance of agentic actions.
+3. **Trusted evidence source:** Required evidence can be generated or corroborated by trusted workflow, authorization, enforcement, backend, or evidence components.
+4. **Pass/fail testability:** The obligation can be evaluated with clear pass, partial, and fail criteria.
+5. **Implementation feasibility:** The requirement can be implemented without assuming a universal identity system, universal agent protocol, or certification scheme.
+6. **Backward compatibility:** The change does not unintentionally redefine the v0.4.1 baseline unless the release explicitly says so.
+7. **Mapping impact:** Any external framework mapping impact is reviewed without claiming compliance equivalence, certification readiness, or audit sufficiency.
+
+### Promotion Decision Record
+
+For each v0.5.0 planning theme, the release preparation process should record:
+
+- the chosen incorporation outcome;
+- affected controls, schema fields, testing procedures, or assessment artifacts;
+- whether the change is normative or guidance-only;
+- expected evidence sources;
+- known implementation burden;
+- residual ambiguity or deferred work.
+
+This decision record may be maintained in the relevant planning issue, release checklist, or future release notes.
+
+
 ## Theme 1: Principal Context Degradation
 
 See: `docs/en/30-principal-context-degradation.md`


### PR DESCRIPTION
## Summary

This PR adds incorporation rules for v0.5.0 planning concepts.

Changes include:

- Clarify that v0.5.0 planning concepts do not become normative AAEF requirements merely by appearing in planning documents
- Define possible incorporation outcomes:
  - planning only
  - guidance only
  - testing refinement
  - evidence refinement
  - existing control refinement
  - new control
- Add promotion criteria for moving planning concepts into normative or assessment artifacts
- Add promotion decision record expectations for release preparation
- Update the v0.5.0 planning overview pointer
- Add an Unreleased changelog entry

## Validation

Validated locally:

```text
OK: 44 assessment profile mapping rows validated.
OK: 44 assessment worksheet rows validated.
OK: 44 controls validated.
OK: 44 testing procedure rows validated.
OK: 10 external framework mapping rows validated.
OK: evidence schema and examples validated.
````

## Impact

This is a documentation clarification update.

It does not change:

* control catalog CSV
* assessment worksheet
* assessment profiles
* testing procedure CSV
* external framework mapping CSV
* evidence schema
* evidence examples