### PR TITLE
Refine cross-agent authority lifecycle guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Refined cross-agent authority lifecycle guidance for capability-scoped delegation, explicit acceptance or refusal, delegation chain limits, evidence linkage, and budget propagation.
 - Added a non-normative v0.5.0 evidence integrity levels model for risk-proportional evidence, tamper-evident storage, and performance overhead tradeoffs.
 - Added `docs/en/18-implementation-guidance.md` to close the documentation numbering gap and provide non-normative implementation adoption guidance.
 - Added a non-normative v0.5.0 authority lifecycle model covering principal context degradation, cross-agent authority, denial, freeze, revocation, and reauthorization.

--- a/docs/en/34-v050-control-design-options.md
+++ b/docs/en/34-v050-control-design-options.md
@@ -94,7 +94,7 @@ These outcomes are planning assumptions only. They do not change the v0.4.1 base
 | Planning theme | Primary expected outcome | Secondary possible outcome | Current disposition |
 | --- | --- | --- | --- |
 | Principal Context Degradation | Existing control refinement | Guidance and testing refinement | Treat as a cross-cutting authority lifecycle concept that may refine authorization, delegation, memory, and governance controls without immediately creating a new control ID. |
-| Cross-Agent and Cross-Domain Authority | Existing control refinement | New control candidate if existing delegation and authorization controls cannot express cross-boundary handoff risk | Keep as a planning topic until the framework determines whether cross-agent authority is a refinement of existing delegation controls or a distinct assessable obligation. |
+| Cross-Agent and Cross-Domain Authority | Existing control refinement | New control candidate if existing controls cannot express capability-scoped delegation, explicit acceptance or refusal, delegation chain limits, or cross-agent budget propagation | Keep as a planning topic until the framework determines whether cross-agent authority is a refinement of existing delegation controls or a distinct assessable obligation. |
 | Authority Denial and Reauthorization Flow | Testing refinement | Evidence refinement and existing control refinement | Treat primarily as a testable behavior for denial, freeze, expiry, and reauthorization paths before deciding whether new control text is needed. |
 | Risk-Proportional Evidence and Performance Overhead | Guidance only | Evidence refinement and assessment profile refinement | Treat as implementation and assessment guidance unless specific evidence expectations become required for higher assurance levels. |
 | Tamper-Evident Evidence Storage | Evidence refinement | New control candidate for high-impact or audit-grade profiles | Keep as an evidence-integrity planning topic. Avoid requiring tamper-evident storage universally unless scoped to higher-risk profiles. |
@@ -215,6 +215,23 @@ Use a hybrid approach:
 - consider a new `AAEF-PRN-03` only if the strengthened `AAEF-PRN-02` becomes too broad.
 
 For v0.5.0, the preferred first step is to strengthen `AAEF-PRN-02` and testing procedures before adding a new control.
+
+## Cross-Agent Delegation Design Considerations
+
+The cross-agent authority planning theme should explicitly distinguish communication from delegation authority.
+
+A future incorporation decision should consider whether existing controls can express the following obligations, or whether a new cross-agent control family or control IDs are required:
+
+- inter-agent communication does not imply authority to delegate;
+- cross-agent delegation authority should be capability-scoped;
+- receiving agents should explicitly accept or refuse delegated tasks;
+- refusal should propagate back to the requesting agent or workflow;
+- delegation chains should have depth limits and reauthorization expectations;
+- delegation chain evidence should preserve accountability across hops;
+- delegated agents should inherit budget, quota, rate, time, or resource ceilings;
+- gateway, dispatcher, workflow, or backend enforcement should prevent unbounded downstream delegation.
+
+These considerations remain non-normative until incorporated into control, testing, evidence, assessment, or release artifacts.
 
 ## Theme 2: Cross-Agent and Cross-Domain Authority
 

--- a/docs/en/50-authority-lifecycle-model.md
+++ b/docs/en/50-authority-lifecycle-model.md
@@ -97,6 +97,94 @@ At minimum, a handoff should preserve:
 
 If these elements cannot be preserved or corroborated, the downstream component should treat the authority context as degraded or unbound.
 
+## Cross-Agent Delegation Authority
+
+Inter-agent communication is not delegation authority.
+
+The ability of one agent, workflow, or tool to communicate with another does not imply that it has authority to delegate work, spend resources, invoke capabilities, or expand the scope of the original principal's authorization.
+
+Cross-agent delegation should be treated as an authority-bearing transition, not merely as a message-passing event.
+
+### Capability-Scoped Delegation
+
+Cross-agent authority should be capability-scoped rather than merely agent-scoped.
+
+For example, Agent A may be authorized to request information from Agent B, but not to delegate an action that modifies data, spends money, contacts an external party, or triggers a high-impact operation.
+
+A cross-agent delegation context should identify, where applicable:
+
+- requesting agent;
+- receiving agent;
+- source principal;
+- delegated capability;
+- action type;
+- target or resource;
+- allowed scope;
+- budget or resource ceiling;
+- validity window or expiry;
+- maximum delegation depth;
+- whether downstream delegation is allowed;
+- policy context and constraints.
+
+If the requested capability is not covered by the delegation context, the receiving agent should treat the request as unauthorized or require reauthorization.
+
+### Explicit Delegation Acceptance and Refusal
+
+Delegation should not be treated as fire-and-forget.
+
+A receiving agent should be able to explicitly accept or refuse a delegated task before the delegating agent proceeds as if the task will be performed.
+
+The delegation response should distinguish:
+
+| Delegation response | Meaning | Expected behavior |
+| --- | --- | --- |
+| Accepted | The receiving agent accepts the delegated task within the provided authority scope. | The delegating workflow may proceed based on the accepted delegation. |
+| Refused | The receiving agent refuses the task and provides a reason or refusal category. | The delegating workflow must not assume execution and should handle denial, fallback, escalation, or reauthorization. |
+| Ambiguous | The receiving agent response does not clearly accept or refuse. | Treat as not accepted; require clarification or reauthorization. |
+| Expired | The delegation request or authority context is no longer valid. | Do not execute; require renewed delegation authority. |
+| Out of scope | The request exceeds the delegated capability, budget, target, or validity window. | Refuse or require reauthorization before execution. |
+
+Refusal propagation is important. If a downstream agent refuses a delegated task, that refusal should propagate back to the requesting agent or workflow in a way that prevents silent continuation under a false assumption of execution.
+
+### Delegation Chain Limits and Accountability
+
+Delegation chains should have explicit limits.
+
+Without depth limits, reauthorization expectations, and evidence linkage, accountability can become difficult to reconstruct as authority passes from Agent A to Agent B, then to Agent C, and onward.
+
+A delegation chain should preserve:
+
+- the original principal or authority source;
+- each delegating and receiving agent;
+- delegated capability and scope at each hop;
+- maximum permitted delegation depth;
+- whether each hop was accepted or refused;
+- reauthorization events at each required level;
+- budget and resource constraints at each hop;
+- evidence linkage between delegation records.
+
+For higher-integrity contexts, delegation evidence may use hash linkage, signatures, sequence identifiers, append-only records, or other mechanisms that make delegation chain modification detectable.
+
+This document does not require a specific cryptographic mechanism. Such mechanisms may be appropriate for higher evidence integrity levels or audit-grade contexts.
+
+### Cross-Agent Budget and Resource Propagation
+
+Delegated agents should not receive unconstrained resource authority merely because they receive a delegated task.
+
+When Agent A delegates to Agent B, Agent B should inherit bounded constraints such as budget, quota, rate limit, time limit, tool-use limit, or other resource ceilings appropriate to the original authorization.
+
+Cross-agent budget propagation helps prevent:
+
+- unbounded downstream delegation;
+- resource exhaustion;
+- cost amplification;
+- uncontrolled external service use;
+- unexpected high-impact side effects;
+- accountability gaps between the delegating and receiving agents.
+
+Budget and resource constraints should be enforced by a trusted gateway, dispatcher, workflow engine, backend service, or equivalent enforcement point where feasible.
+
+
 ## Denial, Freeze, Revocation, and Reauthorization
 
 Authority denial and reauthorization are not exceptional edge cases. They are normal lifecycle transitions that must be testable.
@@ -126,6 +214,8 @@ Authority lifecycle evidence should allow a reviewer to reconstruct:
 - what action, target, scope, and policy context were evaluated;
 - whether the authority decision had an expiry or validity window;
 - whether delegation or handoff occurred;
+- what capability, budget, resource, and delegation depth constraints applied;
+- whether downstream delegation was accepted, refused, expired, or out of scope;
 - whether principal context degradation was detected;
 - whether denial, freeze, revocation, expiry, or reauthorization occurred;
 - whether execution matched the verified authority scope.
@@ -153,7 +243,7 @@ The expected incorporation path is:
 | Planning theme | Likely incorporation path |
 | --- | --- |
 | Principal Context Degradation | Existing control refinement, guidance, and testing refinement |
-| Cross-Agent and Cross-Domain Authority | Existing control refinement, with possible new control candidate if cross-boundary authority cannot be expressed by existing controls |
+| Cross-Agent and Cross-Domain Authority | Existing control refinement, with possible new control candidate for capability-scoped delegation, explicit acceptance or refusal, delegation chain limits, or cross-agent budget propagation if existing controls cannot express these obligations |
 | Authority Denial and Reauthorization Flow | Testing refinement, evidence refinement, and possible existing control refinement |
 
 Any future normative incorporation should follow the incorporation rules and outcome register in `docs/en/34-v050-control-design-options.md`.


### PR DESCRIPTION
## Summary

This PR refines the non-normative v0.5.0 authority lifecycle guidance for cross-agent and cross-domain authority.

Changes include:

- Clarify that inter-agent communication is not delegation authority
- Add capability-scoped delegation guidance
- Add explicit delegation acceptance and refusal expectations
- Clarify refusal propagation back to the requesting agent or workflow
- Add delegation chain limits and accountability guidance
- Add delegation chain evidence linkage expectations
- Add cross-agent budget and resource propagation guidance
- Update the v0.5.0 control design options to capture these cross-agent design considerations
- Add an Unreleased changelog entry

## Validation

Validated locally:

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a non-normative planning documentation update.

It does not change:

- control catalog CSV
- assessment worksheet
- assessment profiles
- testing procedure CSV
- external framework mapping CSV
- evidence schema
- evidence examples

## Related

Related planning issue:

- #3

Milestone: v0.5.0 Planning

Labels: documentation, planning, v0.5.0, authority