### PR TITLE
Add approval quality model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Added a non-normative v0.5.0 approval quality model for meaningful approval, approval context sufficiency, batch approval risk, approval fatigue, and approval evidence expectations.
 - Refined cross-agent authority lifecycle guidance for capability-scoped delegation, explicit acceptance or refusal, delegation chain limits, evidence linkage, and budget propagation.
 - Added a non-normative v0.5.0 evidence integrity levels model for risk-proportional evidence, tamper-evident storage, and performance overhead tradeoffs.
 - Added `docs/en/18-implementation-guidance.md` to close the documentation numbering gap and provide non-normative implementation adoption guidance.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 
 ## Planning Material Boundary
 
-Documents under `docs/en/30-51` are v0.5.0 planning materials. They are non-normative unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
+Documents under `docs/en/30-52` are v0.5.0 planning materials. They are non-normative unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 These documents currently remain under `docs/en/` for public review continuity. A future release may move them into a dedicated planning directory if the repository structure is reorganized.
 
@@ -260,6 +260,7 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │       ├── 49-tamper-evident-evidence-negative-tests.md
 │       ├── 50-authority-lifecycle-model.md
 │       ├── 51-evidence-integrity-levels.md
+│       ├── 52-approval-quality-model.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/33-v050-planning-overview.md
+++ b/docs/en/33-v050-planning-overview.md
@@ -19,7 +19,8 @@ This document does not add new controls, schema fields, or assessment requiremen
 For control design tradeoffs, incorporation rules, and the preliminary outcome register before changing the catalog, see `docs/en/34-v050-control-design-options.md`.
 
 For a consolidated authority lifecycle model covering Principal Context Degradation, Cross-Agent and Cross-Domain Authority, and Authority Denial and Reauthorization Flow, see `docs/en/50-authority-lifecycle-model.md`
-- `docs/en/51-evidence-integrity-levels.md`.
+- `docs/en/51-evidence-integrity-levels.md`
+- `docs/en/52-approval-quality-model.md`.
 
 ## v0.5.0 Core Design Themes
 
@@ -325,3 +326,5 @@ The following non-normative example documents illustrate how selected v0.5.0 pla
 - Tamper-evident evidence negative tests: `docs/en/49-tamper-evident-evidence-negative-tests.md`
 
 For a risk-proportional evidence integrity model covering tamper-evident storage, trusted evidence generation, and performance overhead tradeoffs, see `docs/en/51-evidence-integrity-levels.md`.
+
+For an approval quality model covering meaningful approval, context sufficiency, batch approval risk, approval fatigue, and approval evidence expectations, see `docs/en/52-approval-quality-model.md`.

--- a/docs/en/34-v050-control-design-options.md
+++ b/docs/en/34-v050-control-design-options.md
@@ -98,7 +98,7 @@ These outcomes are planning assumptions only. They do not change the v0.4.1 base
 | Authority Denial and Reauthorization Flow | Testing refinement | Evidence refinement and existing control refinement | Treat primarily as a testable behavior for denial, freeze, expiry, and reauthorization paths before deciding whether new control text is needed. |
 | Risk-Proportional Evidence and Performance Overhead | Guidance only | Evidence refinement and assessment profile refinement | Treat as implementation and assessment guidance unless specific evidence expectations become required for higher assurance levels. |
 | Tamper-Evident Evidence Storage | Evidence refinement | New control candidate for high-impact or audit-grade profiles | Keep as an evidence-integrity planning topic. Avoid requiring tamper-evident storage universally unless scoped to higher-risk profiles. |
-| Approval Quality and Approval Fatigue | Existing control refinement | New HUM control candidate if approval quality cannot be adequately represented by existing HUM controls | Treat as a human-approval assurance refinement while preserving the distinction between meaningful approval and approval UI presence. |
+| Approval Quality and Approval Fatigue | Existing HUM control refinement | Guidance, testing refinement, or new HUM control candidate if approval quality cannot be adequately represented by existing HUM controls | Treat as a human-approval assurance refinement while preserving the distinction between meaningful approval, approval evidence, approval context quality, and approval UI presence. |
 
 ### Outcome Review Questions
 
@@ -511,5 +511,13 @@ That model should be used as shared design context before promoting any of the f
 
 - Risk-Proportional Evidence and Performance Overhead;
 - Tamper-Evident Evidence Storage.
+
+The model is non-normative and does not itself change the v0.4.1 baseline.
+
+## Approval Quality Model Relationship
+
+The current human-approval planning theme is consolidated in `docs/en/52-approval-quality-model.md`.
+
+That model should be used as shared design context before promoting Approval Quality and Approval Fatigue into normative or assessment artifacts.
 
 The model is non-normative and does not itself change the v0.4.1 baseline.

--- a/docs/en/52-approval-quality-model.md
+++ b/docs/en/52-approval-quality-model.md
@@ -1,0 +1,193 @@
+# Approval Quality Model
+
+**Status:** Non-normative v0.5.0 planning model
+
+> **Planning status:** This document is non-normative v0.5.0 planning material. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
+
+## Purpose
+
+This document defines a non-normative planning model for approval quality and approval fatigue in AAEF.
+
+It connects the current v0.5.0 planning theme:
+
+- Approval Quality and Approval Fatigue
+
+The purpose is to distinguish meaningful human approval from superficial approval UI, rubber-stamping, bulk confirmation, or approval flows that do not provide enough context for the approver to make an informed decision.
+
+This model does not introduce new control requirements by itself.
+
+## Design Rationale
+
+Human approval is often used as a safety boundary for agentic actions.
+
+However, a human approval step does not automatically create assurance.
+
+Approval quality depends on whether the approver receives enough information, has appropriate authority, understands the action and its consequences, and approves a specific action within a clear scope.
+
+AAEF planning should avoid treating the presence of an approval button as equivalent to meaningful authorization.
+
+## Approval Quality Dimensions
+
+| Dimension | Description | Primary risk |
+| --- | --- | --- |
+| Approver identity | The system records who approved the action and whether that approver was eligible. | Approval is anonymous, spoofed, delegated incorrectly, or performed by an unauthorized actor. |
+| Action specificity | The approval is tied to a specific action, target, scope, and expected effect. | Approval is reused for actions the approver did not review. |
+| Context sufficiency | The approver receives enough risk, policy, evidence, and consequence information. | The approver cannot make an informed decision. |
+| Scope clarity | The approval has clear limits, validity window, target, and constraints. | Approval is interpreted more broadly than intended. |
+| Risk visibility | The approver can see whether the action is high-impact, irreversible, privileged, sensitive, or unusual. | High-risk actions are approved as if they were routine. |
+| Alternatives and denial path | The approver can deny, defer, escalate, or request changes. | Approval becomes a forced confirmation step. |
+| Fatigue resistance | The workflow limits repetitive, low-information, or excessive approval prompts. | Approvers rubber-stamp actions due to volume or poor UI design. |
+| Evidence capture | The approval event is recorded with enough detail for later assessment or incident review. | Auditors cannot determine what was approved, by whom, and under what context. |
+
+## Meaningful Approval
+
+Meaningful approval requires more than a user click.
+
+A meaningful approval should be:
+
+- tied to a specific action or bounded action set;
+- tied to an identified approver;
+- based on sufficient context;
+- limited by scope and validity period where appropriate;
+- recorded as action-bound evidence;
+- enforceable by a trusted component;
+- revocable, deniable, or rejectable where the workflow requires it.
+
+The approver should not need to infer critical details solely from model-generated summaries.
+
+## Approval Context Sufficiency
+
+Approval context is sufficient when it allows the approver to understand what is being authorized.
+
+Depending on the action risk, approval context may include:
+
+- action type;
+- target system, object, user, tenant, or resource;
+- expected effect;
+- risk tier or impact category;
+- whether the action is reversible;
+- whether the action involves external communication, data modification, privilege change, financial impact, or destructive operation;
+- requesting agent or workflow;
+- relevant policy decision or recommendation;
+- evidence summary or supporting context;
+- expiry or validity window;
+- known constraints, exclusions, or assumptions.
+
+For high-impact actions, approval context should be specific enough that a later reviewer can determine whether the approver authorized the executed action, not merely a vague category of activity.
+
+## Approval Fatigue
+
+Approval fatigue occurs when approvers are asked to approve too many actions, too frequently, with too little context, or with poor differentiation between routine and high-risk actions.
+
+Approval fatigue can cause:
+
+- rubber-stamping;
+- missed high-risk actions;
+- overreliance on defaults;
+- approval of unclear or bundled actions;
+- reduced attention to exception conditions;
+- loss of trust in the approval workflow.
+
+Approval fatigue is an assurance risk because it weakens the reliability of human approval as a control.
+
+## Batch Approval and Bundling Risk
+
+Batch approvals can be useful, but they create additional risk.
+
+A batch approval should make clear:
+
+- which actions are included;
+- which actions are excluded;
+- whether the approval applies to each action individually or to the batch as a whole;
+- whether the batch contains mixed-risk actions;
+- whether any action in the batch requires separate approval;
+- how denied or partially approved items are handled;
+- how the approval evidence links to each executed action.
+
+High-impact or irreversible actions should not be hidden inside broad, low-information batches.
+
+## Approval State Model
+
+The following state model is a planning aid.
+
+| Approval state | Meaning | Expected behavior |
+| --- | --- | --- |
+| Not required | The action does not require human approval under the applicable policy. | Proceed according to non-human authorization controls. |
+| Required | The action requires approval before execution. | Block execution until valid approval is recorded. |
+| Requested | Approval has been requested but not yet granted or denied. | Do not execute the approval-gated action. |
+| Approved | An eligible approver approved the action within scope. | Execute only within the approved scope and validity window. |
+| Denied | The approver rejected the action. | Do not execute; record denial evidence. |
+| Expired | The approval is no longer valid. | Require renewed approval before execution. |
+| Revoked | Previously granted approval has been withdrawn. | Stop dependent execution and invalidate cached approval. |
+| Escalated | The action requires additional review or higher authority. | Do not execute until escalation is resolved. |
+| Partial | Only part of a requested action set was approved. | Execute only the approved portion, if safe and supported. |
+| Ambiguous | Approval context, scope, approver, or target is unclear. | Treat as insufficient approval and require clarification or reauthorization. |
+
+## Evidence Expectations
+
+Approval evidence should allow a reviewer to reconstruct:
+
+- who requested approval;
+- which action or action set was approved;
+- who approved, denied, escalated, or revoked approval;
+- whether the approver was eligible;
+- what context was shown to the approver;
+- what risk level or impact category was presented;
+- when approval was requested and granted;
+- whether the approval had an expiry, scope, or validity window;
+- whether the executed action matched the approved scope;
+- whether approval was denied, expired, revoked, partial, or ambiguous.
+
+Approval evidence should not rely solely on model-generated explanations, screenshots without structured context, or agent runtime self-reporting.
+
+## Approval Anti-Patterns
+
+Implementers should avoid:
+
+- generic “approve all” prompts for mixed-risk actions;
+- approval prompts that omit target, effect, or risk context;
+- approvals that are not tied to specific executed actions;
+- approval records without approver identity;
+- approvals generated or modified by the agent being approved;
+- approval reuse outside the original scope;
+- approval after execution when pre-execution approval was required;
+- approval flows where denial or escalation is unavailable;
+- treating conversation text as durable approval for later actions;
+- hiding high-impact actions inside low-risk batches.
+
+## Relationship to Existing AAEF Artifacts
+
+This planning model may inform future refinements to:
+
+- human approval controls;
+- authorization controls;
+- delegation controls;
+- testing procedures for approval-gated actions;
+- evidence expectations for approval records;
+- high-impact and audit-grade prequalification guidance.
+
+The model does not itself change the v0.4.1 control catalog, assessment worksheet, testing procedures, evidence schema, or external framework mappings.
+
+## Relationship to HUM Controls
+
+This model is especially relevant to human approval and human oversight controls.
+
+Future incorporation may refine existing HUM controls or introduce additional control language if approval quality and approval fatigue cannot be adequately represented by existing controls.
+
+Any such incorporation should preserve the distinction between:
+
+- approval UI presence;
+- approval evidence;
+- approval authority;
+- approval context quality;
+- approval effectiveness under realistic workload.
+
+## Preliminary Incorporation Outcome
+
+The expected incorporation path is:
+
+| Planning theme | Likely incorporation path |
+| --- | --- |
+| Approval Quality and Approval Fatigue | Existing HUM control refinement, guidance, testing refinement, and possible new HUM control candidate if approval quality cannot be adequately represented by existing controls |
+
+Any future normative incorporation should follow the incorporation rules and outcome register in `docs/en/34-v050-control-design-options.md`.


### PR DESCRIPTION
## Summary

This PR adds a non-normative v0.5.0 approval quality model.

Changes include:

- Add `docs/en/52-approval-quality-model.md`
- Consolidate the Approval Quality and Approval Fatigue planning theme
- Define approval quality dimensions, including approver identity, action specificity, context sufficiency, scope clarity, risk visibility, denial paths, fatigue resistance, and evidence capture
- Clarify the difference between meaningful approval and superficial approval UI
- Define approval states such as required, requested, approved, denied, expired, revoked, escalated, partial, and ambiguous
- Add approval evidence expectations and approval anti-patterns
- Link the model from the v0.5.0 planning overview and control design options
- Update README planning material references from `docs/en/30-51` to `docs/en/30-52`
- Add an Unreleased changelog entry

## Validation

Validated locally:

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a non-normative planning documentation update.

It does not change:

- control catalog CSV
- assessment worksheet
- assessment profiles
- testing procedure CSV
- external framework mapping CSV
- evidence schema
- evidence examples

## Related

Related planning issue:

- #6

Milestone: v0.5.0 Planning

Labels: documentation, planning, v0.5.0, control