### PR TITLE
Add v0.5.0 release scope decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Added a v0.5.0 release scope decision record clarifying that current planning models remain non-normative unless explicitly incorporated into future normative or assessment artifacts.
 - Added a non-normative v0.5.0 approval quality model for meaningful approval, approval context sufficiency, batch approval risk, approval fatigue, and approval evidence expectations.
 - Refined cross-agent authority lifecycle guidance for capability-scoped delegation, explicit acceptance or refusal, delegation chain limits, evidence linkage, and budget propagation.
 - Added a non-normative v0.5.0 evidence integrity levels model for risk-proportional evidence, tamper-evident storage, and performance overhead tradeoffs.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The Markdown control list in `docs/en/07-control-requirements.md` is maintained 
 
 ## Planning Material Boundary
 
-Documents under `docs/en/30-52` are v0.5.0 planning materials. They are non-normative unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
+Documents under `docs/en/30-53` are v0.5.0 planning materials. They are non-normative unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
 
 These documents currently remain under `docs/en/` for public review continuity. A future release may move them into a dedicated planning directory if the repository structure is reorganized.
 
@@ -261,6 +261,7 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │       ├── 50-authority-lifecycle-model.md
 │       ├── 51-evidence-integrity-levels.md
 │       ├── 52-approval-quality-model.md
+│       ├── 53-v050-release-scope-decision.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/33-v050-planning-overview.md
+++ b/docs/en/33-v050-planning-overview.md
@@ -20,7 +20,8 @@ For control design tradeoffs, incorporation rules, and the preliminary outcome r
 
 For a consolidated authority lifecycle model covering Principal Context Degradation, Cross-Agent and Cross-Domain Authority, and Authority Denial and Reauthorization Flow, see `docs/en/50-authority-lifecycle-model.md`
 - `docs/en/51-evidence-integrity-levels.md`
-- `docs/en/52-approval-quality-model.md`.
+- `docs/en/52-approval-quality-model.md`
+- `docs/en/53-v050-release-scope-decision.md`.
 
 ## v0.5.0 Core Design Themes
 
@@ -328,3 +329,5 @@ The following non-normative example documents illustrate how selected v0.5.0 pla
 For a risk-proportional evidence integrity model covering tamper-evident storage, trusted evidence generation, and performance overhead tradeoffs, see `docs/en/51-evidence-integrity-levels.md`.
 
 For an approval quality model covering meaningful approval, context sufficiency, batch approval risk, approval fatigue, and approval evidence expectations, see `docs/en/52-approval-quality-model.md`.
+
+For the v0.5.0 release scope decision and disposition of current planning themes, see `docs/en/53-v050-release-scope-decision.md`.

--- a/docs/en/34-v050-control-design-options.md
+++ b/docs/en/34-v050-control-design-options.md
@@ -33,6 +33,14 @@ v0.5.0 control design should follow these principles:
 6. Preserve AAEF's core premise: model output is not authority.
 7. Keep v0.5.0 implementable for real agentic AI systems.
 
+## v0.5.0 Release Scope Decision Relationship
+
+The current v0.5.0 release scope decision is recorded in `docs/en/53-v050-release-scope-decision.md`.
+
+That document should be used when deciding whether each planning theme remains non-normative guidance, becomes a v0.5.x follow-up item, or is later incorporated into control, evidence, assessment, testing, mapping, or release artifacts.
+
+For v0.5.0, the intended disposition is to keep the current planning models non-normative unless later release artifacts explicitly incorporate them.
+
 ## Normative Incorporation Rules
 
 v0.5.0 planning concepts do not become normative AAEF requirements merely because they are described in planning documents.

--- a/docs/en/53-v050-release-scope-decision.md
+++ b/docs/en/53-v050-release-scope-decision.md
@@ -1,0 +1,118 @@
+# v0.5.0 Release Scope Decision
+
+**Status:** Non-normative v0.5.0 planning decision record
+
+> **Planning status:** This document records the intended v0.5.0 planning scope. It is not part of the normative v0.4.1 Public Review Draft baseline unless explicitly incorporated into the control catalog, evidence schema, assessment artifacts, testing procedures, or release notes.
+
+## Purpose
+
+This document records the intended scope decision for AAEF v0.5.0 planning work.
+
+The v0.5.0 planning cycle introduced several models and design notes for authority lifecycle, evidence integrity, approval quality, and incorporation rules.
+
+The purpose of this document is to decide how those planning topics should be treated for the v0.5.0 release, and to separate:
+
+- non-normative planning models;
+- implementation and assessment guidance;
+- future testing or evidence refinements;
+- future existing-control refinements;
+- possible new control candidates;
+- deferred v0.5.x work.
+
+## Scope Decision Summary
+
+AAEF v0.5.0 should be treated as a planning-model and incorporation-framework release.
+
+For v0.5.0, the planning models should remain non-normative unless a later release explicitly incorporates them into normative or assessment artifacts.
+
+This means v0.5.0 should not, by itself, change:
+
+- the control catalog CSV;
+- the human-readable control requirements;
+- the assessment worksheet;
+- the assessment profiles;
+- the testing procedure CSV;
+- the evidence schema;
+- the evidence examples;
+- the external framework mapping CSV.
+
+The planning models should instead provide structured design input for later v0.5.x refinements.
+
+## v0.5.0 Planning Themes and Release Disposition
+
+| Planning theme | Primary disposition for v0.5.0 | Future incorporation path | Related material |
+| --- | --- | --- | --- |
+| Principal Context Degradation | Non-normative planning model | Existing control refinement, guidance, and testing refinement candidate | `docs/en/30-principal-context-degradation.md`, `docs/en/50-authority-lifecycle-model.md` |
+| Cross-Agent and Cross-Domain Authority | Non-normative planning model | Existing control refinement or new cross-agent control candidate if existing controls cannot express capability-scoped delegation, explicit acceptance/refusal, delegation chain limits, or budget propagation | `docs/en/31-cross-agent-cross-domain-authority.md`, `docs/en/50-authority-lifecycle-model.md` |
+| Authority Denial and Reauthorization Flow | Non-normative planning model | Testing refinement, evidence refinement, and existing control refinement candidate | `docs/en/32-authority-denial-reauthorization-flow.md`, `docs/en/50-authority-lifecycle-model.md` |
+| Risk-Proportional Evidence and Performance Overhead | Non-normative planning model | Guidance, evidence refinement, and assessment profile refinement candidate | `docs/en/36-risk-proportional-evidence-profile.md`, `docs/en/51-evidence-integrity-levels.md` |
+| Tamper-Evident Evidence Storage | Non-normative planning model | Evidence refinement and possible high-impact or audit-grade profile requirement candidate | `docs/en/37-tamper-evident-evidence-storage.md`, `docs/en/51-evidence-integrity-levels.md` |
+| Approval Quality and Approval Fatigue | Non-normative planning model | Existing HUM control refinement, guidance, testing refinement, or new HUM control candidate | `docs/en/39-approval-quality-approval-fatigue.md`, `docs/en/52-approval-quality-model.md` |
+
+## v0.5.0 Included Planning Models
+
+The following planning models are in scope for v0.5.0 as non-normative planning material:
+
+| Document | Scope |
+| --- | --- |
+| `docs/en/34-v050-control-design-options.md` | Incorporation rules, outcome register, and control design options for v0.5.0 planning topics |
+| `docs/en/50-authority-lifecycle-model.md` | Authority lifecycle model covering principal context degradation, cross-agent authority, denial, freeze, revocation, expiry, and reauthorization |
+| `docs/en/51-evidence-integrity-levels.md` | Evidence integrity levels model covering risk-proportional evidence, tamper-evident evidence, and performance overhead tradeoffs |
+| `docs/en/52-approval-quality-model.md` | Approval quality model covering meaningful approval, context sufficiency, approval fatigue, batch approval risk, and approval evidence expectations |
+| `docs/en/53-v050-release-scope-decision.md` | Release scope decision record for v0.5.0 planning material |
+
+## Explicitly Out of Scope for v0.5.0
+
+The following are out of scope for v0.5.0 unless a later PR explicitly changes this decision:
+
+- adding new control IDs;
+- changing existing control requirements;
+- changing the control catalog CSV;
+- changing required evidence schema fields;
+- changing evidence example validity expectations;
+- changing testing procedure pass/fail criteria;
+- changing assessment worksheet fields;
+- changing assessment profile mappings;
+- claiming compliance equivalence with external frameworks;
+- treating v0.5.0 planning notes as certification, audit, or conformance criteria.
+
+## Deferred v0.5.x Candidate Work
+
+The following work should be considered for v0.5.x follow-up releases.
+
+| Candidate work | Possible artifact impact |
+| --- | --- |
+| Principal context degradation testing criteria | Testing procedures, control guidance, assessment methodology |
+| Cross-agent capability-scoped delegation controls | Control catalog, control requirements, testing procedures, evidence expectations |
+| Delegation acceptance/refusal and chain accountability tests | Testing procedures, evidence examples, authority lifecycle guidance |
+| Cross-agent budget propagation | New or refined control guidance, resource governance controls, assessment guidance |
+| Evidence integrity levels for high-impact or audit-grade profiles | Assessment profiles, evidence guidance, prequalification guidance |
+| Tamper-evident evidence requirements for selected contexts | Evidence guidance, testing procedures, possibly schema or examples |
+| Approval context sufficiency and fatigue tests | HUM controls, testing procedures, assessment guidance, evidence expectations |
+
+## Issue Handling Decision
+
+The current v0.5.0 planning issues should not be closed merely because a planning model exists.
+
+They should remain open until the project decides one of the following for each issue:
+
+- close as addressed by non-normative planning guidance;
+- close after incorporation into a normative or assessment artifact;
+- convert into a narrower v0.5.x follow-up issue;
+- defer explicitly as future research or implementation guidance.
+
+## Release Note Guidance
+
+The v0.5.0 release notes should state that v0.5.0 is a planning and design-clarification release.
+
+Recommended release note language:
+
+AAEF v0.5.0 adds non-normative planning models for authority lifecycle, evidence integrity, and approval quality, and clarifies how planning concepts may be incorporated into future normative or assessment artifacts. It does not change the v0.4.1 control catalog, evidence schema, assessment worksheet, assessment profiles, or testing procedures unless explicitly stated in later release artifacts.
+
+## Relationship to Existing AAEF Artifacts
+
+This decision record is intended to guide v0.5.0 release preparation.
+
+It does not itself change the v0.4.1 baseline.
+
+Future normative incorporation should follow the incorporation rules in `docs/en/34-v050-control-design-options.md` and should update affected control, evidence, assessment, testing, mapping, and release artifacts together.


### PR DESCRIPTION
## Summary

This PR adds a v0.5.0 release scope decision record.

Changes include:

- Add `docs/en/53-v050-release-scope-decision.md`
- Clarify that v0.5.0 should be treated as a planning-model and incorporation-framework release
- Record that current v0.5.0 planning models remain non-normative unless explicitly incorporated into future normative or assessment artifacts
- Summarize the release disposition for the six current v0.5.0 planning themes
- Identify future v0.5.x candidate work for control, testing, evidence, assessment, and profile refinements
- Clarify that v0.5.0 does not change the v0.4.1 control catalog, evidence schema, assessment worksheet, assessment profiles, testing procedures, or external framework mapping CSV
- Link the release scope decision from the v0.5.0 planning overview and control design options
- Update README planning material references from `docs/en/30-52` to `docs/en/30-53`
- Add an Unreleased changelog entry

## Validation

Validated locally:

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a non-normative planning documentation update.

It does not change:

- control catalog CSV
- human-readable control requirements
- assessment worksheet
- assessment profiles
- testing procedure CSV
- external framework mapping CSV
- evidence schema
- evidence examples

## Related

Related planning issues:

- #2
- #3
- #6
- #19
- #20
- #21

Milestone: v0.5.0 Planning

Labels: documentation, planning, v0.5.0