### PR TITLE
Add researcher overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-_No unreleased changes._
+### Added
+
+- Added a researcher overview as a research-facing entry point with reading paths, review questions, and links to open research questions and v0.5.x follow-up work.
 
 ## v0.5.0 Public Review Planning Release - 2026-04-29
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │       ├── 52-approval-quality-model.md
 │       ├── 53-v050-release-scope-decision.md
 │       ├── 54-v050-release-preparation-checklist.md
+│       ├── 55-researcher-overview.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md
@@ -312,7 +313,7 @@ If you reference this work, please cite it as:
 
 ## Research and Open Questions
 
-For research-oriented open questions, see [`docs/en/19-open-research-questions.md`](docs/en/19-open-research-questions.md).
+For a research-facing entry point, see [`docs/en/55-researcher-overview.md`](docs/en/55-researcher-overview.md). For the detailed catalog of open research questions, see [`docs/en/19-open-research-questions.md`](docs/en/19-open-research-questions.md).
 
 ## License
 

--- a/docs/en/19-open-research-questions.md
+++ b/docs/en/19-open-research-questions.md
@@ -8,6 +8,12 @@ These questions are not AAEF control requirements.
 
 They are intended to help researchers, students, reviewers, and implementers identify areas where further empirical study, measurement, experimentation, or formalization may be useful.
 
+## Researcher Overview
+
+A research-facing entry point is maintained in `docs/en/55-researcher-overview.md`.
+
+This document remains the detailed catalog of open research questions. The researcher overview provides project positioning, reading paths, current v0.5.x follow-up areas, and review questions for researchers.
+
 ## Purpose
 
 AAEF is primarily an action assurance framework for agentic AI systems.

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -1,0 +1,187 @@
+# Researcher Overview
+
+**Status:** Non-normative research-facing overview
+
+## Purpose
+
+This document provides a research-oriented entry point to the Agentic Authority and Evidence Framework (AAEF).
+
+It is intended for researchers, reviewers, students, standards participants, security architects, AI governance practitioners, and implementers who want to understand AAEF as a research and design object rather than only as an implementation checklist.
+
+This document does not create new control requirements and does not change the current control and assessment baseline.
+
+## Current Status
+
+AAEF v0.5.0 is the latest public review planning release.
+
+AAEF v0.4.1 remains the current control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, testing procedures, or related normative or assessment artifacts.
+
+The v0.5.0 planning materials are non-normative unless explicitly incorporated into future control, evidence, assessment, testing, mapping, or release artifacts.
+
+## Research Motivation
+
+AAEF focuses on a specific problem in agentic AI assurance:
+
+How should authority, execution boundaries, and evidence be structured when AI agents perform actions on behalf of human or organizational principals?
+
+AAEF does not attempt to make model output itself authoritative.
+
+Instead, AAEF treats authority as something that should be granted, scoped, checked, enforced, evidenced, reviewable, and revocable outside the model output itself.
+
+## Core Research Claims
+
+### Model output is not authority
+
+A model recommendation, plan, tool-call proposal, or explanation should not by itself authorize an action.
+
+Authority should be represented through trusted decision, policy, workflow, approval, backend, or enforcement components rather than inferred from model output alone.
+
+### Authority should be action-bound
+
+Authority should be tied to a principal, action, target, scope, policy context, validity window, and evidence context.
+
+This is especially important for high-impact actions, long-running workflows, delegated tasks, and cross-agent handoffs.
+
+### Evidence is not merely logging
+
+Logs are not automatically evidence.
+
+Evidence should be attributable, action-bound, context-bound, reviewable, and sufficiently independent or corroborated for the assessed action and risk level.
+
+### Inter-agent communication is not delegation authority
+
+An agent may be able to communicate with another agent without being authorized to delegate work, expand scope, spend resources, invoke high-impact capabilities, or cross an authority boundary.
+
+This distinction is central to AAEF's v0.5.x follow-up work on cross-agent and cross-domain authority.
+
+## What v0.5.0 Added
+
+AAEF v0.5.0 added non-normative planning models and decision records for future development.
+
+Key materials include:
+
+| Topic | Document |
+| --- | --- |
+| v0.5.0 planning overview | `docs/en/33-v050-planning-overview.md` |
+| Incorporation rules and outcome register | `docs/en/34-v050-control-design-options.md` |
+| Authority Lifecycle Model | `docs/en/50-authority-lifecycle-model.md` |
+| Evidence Integrity Levels | `docs/en/51-evidence-integrity-levels.md` |
+| Approval Quality Model | `docs/en/52-approval-quality-model.md` |
+| v0.5.0 release scope decision | `docs/en/53-v050-release-scope-decision.md` |
+| v0.5.0 release preparation checklist | `docs/en/54-v050-release-preparation-checklist.md` |
+
+These documents do not change the v0.4.1 control and assessment baseline by themselves.
+
+## Relationship to Open Research Questions
+
+This document is an entry point.
+
+The detailed catalog of open research questions is maintained in:
+
+- `docs/en/19-open-research-questions.md`
+
+Use this document to understand the research framing, reading order, and review priorities.
+
+Use `docs/en/19-open-research-questions.md` to review the detailed unresolved questions and possible research projects.
+
+## Relationship to Existing Research Areas
+
+AAEF intersects with several research and practice areas:
+
+- AI agent safety;
+- AI governance;
+- access control and authorization;
+- auditability and evidence design;
+- workflow security;
+- multi-agent systems;
+- security assurance;
+- GRC and compliance assessment;
+- incident reconstruction;
+- human approval and oversight.
+
+AAEF is narrower than general AI safety and broader than simple logging, prompt guardrails, or tool-use policy.
+
+Its focus is action assurance: whether an agentic action was authorized, bounded, enforced, evidenced, and reviewable.
+
+## Suggested Reading Path for Researchers
+
+Researchers may start with the following sequence:
+
+1. `README.md`
+2. `docs/en/00-introduction.md`
+3. `docs/en/02-core-principles.md`
+4. `docs/en/03-definitions.md`
+5. `docs/en/05-trust-model.md`
+6. `docs/en/16-assurance-model.md`
+7. `docs/en/18-implementation-guidance.md`
+8. `docs/en/19-open-research-questions.md`
+9. `docs/en/33-v050-planning-overview.md`
+10. `docs/en/50-authority-lifecycle-model.md`
+11. `docs/en/51-evidence-integrity-levels.md`
+12. `docs/en/52-approval-quality-model.md`
+13. `docs/en/53-v050-release-scope-decision.md`
+
+For readers focused on cross-agent systems, start with:
+
+1. `docs/en/31-cross-agent-cross-domain-authority.md`
+2. `docs/en/46-cross-agent-authority-examples.md`
+3. `docs/en/50-authority-lifecycle-model.md`
+4. the open Cross-Agent and Cross-Domain Authority umbrella issue and related v0.5.x follow-up issues.
+
+## Current v0.5.x Follow-up Areas
+
+The active v0.5.x follow-up work includes:
+
+- principal context degradation testing criteria;
+- capability-scoped cross-agent delegation controls;
+- delegation acceptance/refusal and chain accountability negative tests;
+- cross-agent budget propagation guidance;
+- evidence integrity levels for high-impact and audit-grade profiles;
+- tamper-evident evidence requirements for selected contexts;
+- approval quality testing and evidence expectations.
+
+These follow-up items may later inform guidance, testing refinements, evidence expectations, assessment profiles, schema candidates, or control refinements.
+
+## Review Questions for Researchers
+
+Feedback is especially useful on the following questions.
+
+### Authority and delegation
+
+- Is the action-bound authority model implementable in real agentic systems?
+- When does principal context degrade enough to require reauthorization?
+- How should authority be attenuated across tools, subgoals, agents, or domains?
+- Should cross-agent capability-scoped delegation become a dedicated control area?
+
+### Evidence and auditability
+
+- What evidence is necessary to reconstruct an agentic action chain?
+- Which evidence artifacts are most useful for incident reconstruction?
+- When is independently generated or corroborated evidence required?
+- When should tamper-evident evidence be required, recommended, or optional?
+
+### Human approval
+
+- When does human approval become meaningful authorization?
+- How should approval fatigue be measured?
+- What evidence proves that approval was bound to the canonical action executed?
+- How should approval, reauthorization, override, and break-glass evidence be distinguished?
+
+### Adversarial behavior
+
+- How can systems detect approval laundering, task splitting, retry-after-denial loops, or authority drift?
+- Which AAEF assumptions are easiest to bypass?
+- Which planning concepts are too broad, too strict, or too vague?
+- Where should AAEF prefer implementation-neutral properties over specific mechanisms?
+
+## Non-Goals
+
+This document is not a control catalog.
+
+It is not an implementation checklist.
+
+It does not claim that AAEF has solved the research questions it identifies.
+
+It does not make v0.5.0 planning material normative.
+
+The purpose is to help researchers and reviewers understand where AAEF currently stands, what problems it is trying to frame, and where focused review or empirical study would be most useful.


### PR DESCRIPTION
## Summary

This PR adds a researcher-facing overview for AAEF.

Changes include:

- Add `docs/en/55-researcher-overview.md`
- Clarify AAEF's research motivation and core research claims
- Distinguish the researcher overview from the detailed open research questions catalog
- Add reading paths for researchers and cross-agent authority reviewers
- Link the researcher overview to v0.5.0 planning models and v0.5.x follow-up areas
- Add review questions for researchers covering authority, evidence, approval, and adversarial behavior
- Update README research links to point to both the researcher overview and open research questions
- Add a cross-link from `docs/en/19-open-research-questions.md` to the researcher overview
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a non-normative documentation update.

It does not change:

- control catalog CSV
- human-readable control requirements
- assessment worksheet
- assessment profiles
- testing procedure CSV
- external framework mapping CSV
- evidence schema
- evidence examples

## Related

Milestone: v0.5.x Follow-up

Labels: documentation, v0.5.x, discussion-needed, research