### PR TITLE
Add document map and v0.5.x follow-up status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added temporary v0.5.x follow-up status tracking under `docs/en/status/`.
+- Added a document map to classify AAEF documents by role without moving existing files.
 - Added non-normative approval quality testing and evidence guidance for v0.5.x follow-up work.
 - Added non-normative tamper-evident evidence requirements guidance for selected v0.5.x contexts.
 - Added non-normative evidence integrity profile guidance for high-impact and audit-grade v0.5.x follow-up work.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │       ├── 60-evidence-integrity-profile-guidance.md
 │       ├── 61-tamper-evident-evidence-requirements.md
 │       ├── 62-approval-quality-testing-guidance.md
+│       ├── document-map.md
+│       └── status/
+│           ├── README.md
+│           └── v050x-follow-up-status.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md
@@ -319,6 +323,8 @@ If you reference this work, please cite it as:
 > Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.5.0 Public Review Planning Release, 2026.
 
 ## Research and Open Questions
+
+For document classification and navigation, see [`docs/en/document-map.md`](docs/en/document-map.md).
 
 For a research-facing entry point, see [`docs/en/55-researcher-overview.md`](docs/en/55-researcher-overview.md). For the detailed catalog of open research questions, see [`docs/en/19-open-research-questions.md`](docs/en/19-open-research-questions.md).
 

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -18,6 +18,12 @@ AAEF v0.4.1 remains the current control and assessment baseline unless a later r
 
 The v0.5.0 planning materials are non-normative unless explicitly incorporated into future control, evidence, assessment, testing, mapping, or release artifacts.
 
+## Document Map and Follow-up Status
+
+For document classification and navigation, see `docs/en/document-map.md`.
+
+For temporary v0.5.x follow-up status, see `docs/en/status/v050x-follow-up-status.md`.
+
 ## Research Motivation
 
 AAEF focuses on a specific problem in agentic AI assurance:

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -1,0 +1,156 @@
+# AAEF Document Map
+
+**Status:** Non-normative navigation and classification aid
+
+## Purpose
+
+This document classifies AAEF documents and related artifacts by role.
+
+It does not move files, change document status, change the current control and assessment baseline, or make planning material normative.
+
+The purpose is to make the repository easier to navigate while preserving existing links and release history.
+
+## Classification Principles
+
+AAEF documents should be understood by role, not only by topic.
+
+The most important distinction is whether a document is:
+
+- current baseline or assessment-relevant material;
+- stable explanatory material;
+- research-facing material;
+- non-normative planning material;
+- non-normative follow-up guidance or testing guidance;
+- examples;
+- temporary status or coordination material.
+
+A document's location or number does not by itself make it normative.
+
+The current baseline is determined by the release notes and explicit baseline statements in the repository.
+
+## Current Baseline and Assessment-Relevant Artifacts
+
+These artifacts are closest to assessment, validation, schema, mapping, or control operation.
+
+| Path | Purpose | Classification |
+| --- | --- | --- |
+| `controls/aaef-controls-v0.1.csv` | Control catalog artifact | Baseline / assessment-relevant artifact |
+| `assessment/aaef-assessment-profiles-v0.3-draft.csv` | Assessment artifact | Baseline / assessment-relevant artifact |
+| `assessment/aaef-assessment-worksheet-v0.2-draft.csv` | Assessment artifact | Baseline / assessment-relevant artifact |
+| `assessment/aaef-testing-procedures-v0.4-draft.csv` | Assessment artifact | Baseline / assessment-relevant artifact |
+| `schemas/agentic-action-evidence-event.schema.json` | Evidence schema artifact | Baseline / assessment-relevant artifact |
+| `examples/agentic-action-evidence-event.audit-grade.json` | Evidence example artifact | Baseline / assessment-relevant artifact |
+| `examples/agentic-action-evidence-event.high-impact.json` | Evidence example artifact | Baseline / assessment-relevant artifact |
+| `examples/agentic-action-evidence-event.invalid.json` | Evidence example artifact | Baseline / assessment-relevant artifact |
+| `examples/agentic-action-evidence-event.json` | Evidence example artifact | Baseline / assessment-relevant artifact |
+| `examples/agentic-action-evidence-event.minimal.json` | Evidence example artifact | Baseline / assessment-relevant artifact |
+| `examples/agentic-action-evidence-event.valid.json` | Evidence example artifact | Baseline / assessment-relevant artifact |
+| `mappings/aaef-external-framework-mapping-v0.4-draft.csv` | External framework mapping artifact | Baseline / assessment-relevant artifact |
+| `mappings/threat-control-assurance-mapping-v0.2-draft.csv` | External framework mapping artifact | Baseline / assessment-relevant artifact |
+
+## Stable Framework Explanation
+
+These documents explain the core framework, terminology, principles, trust model, assurance model, or implementation orientation.
+
+| Path | Purpose | Classification |
+| --- | --- | --- |
+| `docs/en/00-introduction.md` | Framework introduction | Stable explanatory material |
+| `docs/en/01-scope.md` | Framework scope | Stable explanatory material |
+| `docs/en/02-core-principles.md` | Core principles | Stable explanatory material |
+| `docs/en/03-definitions.md` | Definitions | Stable explanatory material |
+| `docs/en/04-threat-model.md` | Threat model | Stable explanatory material |
+| `docs/en/05-trust-model.md` | Trust model | Stable explanatory material |
+| `docs/en/16-assurance-model.md` | Assurance model | Stable explanatory material |
+| `docs/en/18-implementation-guidance.md` | Implementation guidance | Stable explanatory material |
+
+## Research-Facing Material
+
+These documents help researchers, reviewers, students, standards participants, and implementers understand AAEF as a research and design object.
+
+| Path | Purpose | Classification |
+| --- | --- | --- |
+| `docs/en/19-open-research-questions.md` | Detailed open research questions | Research-facing material |
+| `docs/en/55-researcher-overview.md` | Researcher-facing entry point and reading path | Research-facing material |
+
+## v0.5.0 Planning Material
+
+These documents were created to clarify future design direction.
+
+They are non-normative unless a later release explicitly incorporates them into control, evidence, assessment, testing, schema, mapping, or release artifacts.
+
+| Path | Purpose | Classification |
+| --- | --- | --- |
+| `docs/en/30-principal-context-degradation.md` | Principal context degradation concept | Non-normative planning material |
+| `docs/en/31-cross-agent-cross-domain-authority.md` | Cross-agent and cross-domain authority planning | Non-normative planning material |
+| `docs/en/33-v050-planning-overview.md` | v0.5.0 planning overview | Non-normative planning material |
+| `docs/en/34-v050-control-design-options.md` | v0.5.0 control design options and incorporation notes | Non-normative planning material |
+| `docs/en/36-risk-proportional-evidence-profile.md` | Risk-proportional evidence planning | Non-normative planning material |
+| `docs/en/37-tamper-evident-evidence-storage.md` | Tamper-evident evidence storage planning | Non-normative planning material |
+| `docs/en/39-approval-quality-approval-fatigue.md` | Approval quality and approval fatigue planning | Non-normative planning material |
+| `docs/en/50-authority-lifecycle-model.md` | Authority Lifecycle Model | Non-normative planning model |
+| `docs/en/51-evidence-integrity-levels.md` | Evidence Integrity Levels | Non-normative planning model |
+| `docs/en/52-approval-quality-model.md` | Approval Quality Model | Non-normative planning model |
+| `docs/en/53-v050-release-scope-decision.md` | v0.5.0 release scope decision | Release planning / decision record |
+| `docs/en/54-v050-release-preparation-checklist.md` | v0.5.0 release preparation checklist | Release planning / validation checklist |
+
+## v0.5.x Follow-up Guidance and Testing Guidance
+
+These documents capture the first follow-up guidance or testing pass after v0.5.0.
+
+They do not change the v0.4.1 control and assessment baseline by themselves.
+
+| Path | Purpose | Classification |
+| --- | --- | --- |
+| `docs/en/56-capability-scoped-cross-agent-delegation.md` | Capability-scoped cross-agent delegation guidance | Non-normative follow-up guidance |
+| `docs/en/57-cross-agent-delegation-negative-tests.md` | Cross-agent delegation negative tests | Non-normative follow-up testing guidance |
+| `docs/en/58-cross-agent-budget-propagation.md` | Cross-agent budget propagation guidance | Non-normative follow-up guidance |
+| `docs/en/59-principal-context-degradation-testing.md` | Principal context degradation testing guidance | Non-normative follow-up testing guidance |
+| `docs/en/60-evidence-integrity-profile-guidance.md` | Evidence integrity profile guidance | Non-normative follow-up guidance |
+| `docs/en/61-tamper-evident-evidence-requirements.md` | Tamper-evident evidence requirements guidance | Non-normative follow-up guidance |
+| `docs/en/62-approval-quality-testing-guidance.md` | Approval quality testing guidance | Non-normative follow-up testing and evidence guidance |
+
+## Examples
+
+These documents provide explanatory examples, evidence examples, or scenario-oriented material.
+
+| Path | Purpose | Classification |
+| --- | --- | --- |
+| `docs/en/40-approval-evidence-examples.md` | Approval evidence examples | Examples |
+| `docs/en/42-tamper-evident-evidence-examples.md` | Tamper-evident evidence examples | Examples |
+| `docs/en/44-evidence-depth-examples.md` | Evidence depth examples | Examples |
+| `docs/en/45-principal-context-degradation-examples.md` | Principal context degradation examples | Examples |
+| `docs/en/46-cross-agent-authority-examples.md` | Cross-agent authority examples | Examples |
+| `docs/en/48-non-execution-reauthorization-negative-tests.md` | Non-execution and reauthorization negative tests | Examples / non-normative negative test guidance |
+| `docs/en/49-tamper-evident-evidence-negative-tests.md` | Tamper-evident evidence negative tests | Examples / non-normative negative test guidance |
+
+## Temporary Status and Coordination Documents
+
+Temporary status documents are kept under `docs/en/status/`.
+
+They may be removed, replaced, or archived when the related milestone, follow-up work, or incorporation decision is complete.
+
+| Path | Purpose | Classification |
+| --- | --- | --- |
+| _No matching documents in this category yet._ |  |  |
+
+## Physical Organization Policy
+
+This map is intentionally a logical classification layer.
+
+Existing numbered documents remain in place to preserve links, release history, issue references, and review context.
+
+Large-scale physical movement of existing documents should be considered separately, preferably in a future repository-structure cleanup release or milestone.
+
+## Non-Goals
+
+This document does not:
+
+- change the current baseline;
+- change the normative status of any document;
+- move existing documents;
+- close follow-up issues;
+- replace release notes;
+- replace changelog entries;
+- replace milestone tracking.
+
+It is a navigation and classification aid only.

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -1,0 +1,39 @@
+# Status Documents
+
+**Status:** Non-normative status and coordination directory
+
+## Purpose
+
+This directory contains temporary status and coordination documents for active milestones, follow-up work, review tracking, incorporation decisions, and release preparation state.
+
+Documents in this directory are not stable framework guidance.
+
+They may be removed, replaced, or archived when the related milestone or follow-up work is complete.
+
+## Appropriate Contents
+
+This directory may contain:
+
+- milestone status summaries;
+- follow-up issue tracking;
+- incorporation status summaries;
+- review coordination notes;
+- release preparation state;
+- close, promote, defer, or split decision tracking.
+
+## Not Appropriate Contents
+
+This directory should not contain:
+
+- control requirements;
+- evidence schema definitions;
+- assessment criteria;
+- stable implementation guidance;
+- long-term design models;
+- current baseline artifacts.
+
+## Baseline Statement
+
+Documents in this directory do not change the current AAEF control and assessment baseline.
+
+Any normative incorporation must be handled through a later PR that explicitly updates the relevant control, testing, evidence, assessment, schema, mapping, or release artifacts.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -1,0 +1,116 @@
+# v0.5.x Follow-up Status
+
+**Status:** Temporary, non-normative follow-up status document
+
+## Purpose
+
+This document summarizes the current status of the v0.5.x follow-up issues after the initial guidance and testing pass.
+
+It is a temporary coordination document.
+
+It may be removed, replaced, or archived when the v0.5.x follow-up incorporation decisions are complete.
+
+This document does not change the v0.4.1 control and assessment baseline.
+
+## Current Summary
+
+The initial v0.5.x follow-up guidance/testing pass has been completed for the currently tracked follow-up issues #161 through #167.
+
+These updates produced non-normative guidance and testing guidance documents.
+
+They do not update:
+
+- control catalog CSV;
+- human-readable control requirements;
+- assessment worksheet;
+- assessment profiles;
+- testing procedure CSV;
+- external framework mapping CSV;
+- evidence schema;
+- evidence examples.
+
+## Follow-up Issue Status
+
+| Issue | Topic | Initial pass | Document | Remaining decision |
+| --- | --- | --- | --- | --- |
+| #161 | Principal context degradation testing criteria | PR #174 | `docs/en/59-principal-context-degradation-testing.md` | Decide whether degradation signals become testing procedure candidates, assessment profile inputs, evidence/schema candidates, or control refinements. |
+| #162 | Capability-scoped cross-agent delegation controls | PR #171 | `docs/en/56-capability-scoped-cross-agent-delegation.md` | Decide whether guidance remains non-normative, refines existing controls, becomes testing/evidence/schema material, or becomes a future control requirement. |
+| #163 | Delegation acceptance/refusal and chain accountability negative tests | PR #172 | `docs/en/57-cross-agent-delegation-negative-tests.md` | Decide which negative tests become testing procedure candidates, executable fixtures, evidence expectations, schema candidates, or control refinement criteria. |
+| #164 | Cross-agent budget propagation guidance | PR #173 | `docs/en/58-cross-agent-budget-propagation.md` | Decide whether budget propagation remains guidance or becomes authority, governance, evidence, assessment, schema, testing, or control material. |
+| #165 | Evidence integrity levels for high-impact and audit-grade profiles | PR #175 | `docs/en/60-evidence-integrity-profile-guidance.md` | Decide whether evidence integrity bands remain guidance or become assessment profile inputs, schema candidates, testing expectations, or control refinements. |
+| #166 | Tamper-evident evidence requirements for selected contexts | PR #176 | `docs/en/61-tamper-evident-evidence-requirements.md` | Decide which contexts should require tamper-evident evidence and whether evidence fields, E5 examples, or testing candidates should be added. |
+| #167 | Approval quality testing and evidence expectations | PR #177 | `docs/en/62-approval-quality-testing-guidance.md` | Decide which approval quality tests become testing procedure candidates, assessment profile inputs, evidence/schema candidates, or HUM control refinements. |
+
+## Why the Issues Remain Open
+
+The initial guidance/testing pass is complete.
+
+The issues remain open because incorporation decisions are still pending.
+
+The next step is not only to ask whether the concepts are useful, but to decide where each concept belongs.
+
+Possible outcomes include:
+
+- remain non-normative guidance;
+- refine existing controls;
+- become testing procedure candidates;
+- become evidence expectations;
+- become evidence schema candidates;
+- become assessment profile guidance;
+- become implementation guidance;
+- become future control requirements;
+- be deferred or split into later work.
+
+## Incorporation Decision Axes
+
+Future review should consider:
+
+| Axis | Question |
+| --- | --- |
+| Control refinement | Should this concept modify existing control wording or add a future control requirement? |
+| Testing procedure | Should this concept become a test case, pass/fail criterion, or executable fixture? |
+| Evidence expectation | Should this concept define required, recommended, or optional evidence? |
+| Schema candidate | Should new evidence fields be proposed? |
+| Assessment profile | Should this concept affect profile selection, assurance level, or assessment depth? |
+| Implementation guidance | Should this concept be implementation guidance rather than a control requirement? |
+| Research question | Should this remain an open research topic? |
+| Deferral | Should the concept remain out of scope for the next incorporation pass? |
+
+## Review Priorities
+
+Review is especially useful on:
+
+- implementation feasibility;
+- missing abuse cases;
+- evidence and auditability gaps;
+- whether negative tests represent realistic failure modes;
+- whether proposed expectations are too strict, too vague, or too easy to bypass;
+- where non-normative planning should become normative or assessment-relevant;
+- where AAEF should avoid premature control, schema, or testing commitments.
+
+## Relationship to Discussions
+
+The public release and reviewer discussions have been updated to reflect the completion of the initial v0.5.x follow-up pass.
+
+This document exists to keep the same status visible inside the repository.
+
+## Removal or Archive Condition
+
+This document should be removed, replaced, or archived when:
+
+- all #161 through #167 incorporation decisions are resolved;
+- the relevant follow-up issues are closed, split, or superseded;
+- a later release incorporates the selected guidance into stable artifacts;
+- or a new status document replaces this one.
+
+## Non-Goals
+
+This document does not:
+
+- close any issue;
+- promote any guidance to normative status;
+- change the baseline;
+- replace the changelog;
+- replace release notes;
+- replace the document map;
+- define new control, testing, evidence, assessment, or schema requirements.


### PR DESCRIPTION
## Summary

This PR adds repository navigation and temporary follow-up status tracking.

Changes include:

- Add `docs/en/document-map.md`
- Add `docs/en/status/README.md`
- Add `docs/en/status/v050x-follow-up-status.md`
- Classify AAEF documents by role without moving existing files
- Add a temporary status directory for milestone, follow-up, review, and incorporation tracking
- Summarize the initial v0.5.x follow-up guidance/testing pass for #161 through #167
- Clarify that #161 through #167 remain open because incorporation decisions are still pending
- Clarify that status documents are temporary, non-normative, and may be removed, replaced, or archived
- Link the document map and status tracker from the researcher overview
- Add README repository tree entries
- Add Unreleased changelog entries

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a non-normative documentation and navigation update.

It does not:

- move existing documents
- close any follow-up issue
- change the current baseline
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change testing procedure CSV
- change external framework mapping CSV
- change evidence schema
- change evidence examples

## Related

Related follow-up issues:

- #161
- #162
- #163
- #164
- #165
- #166
- #167

Related umbrella issue:

- #3

Milestone: v0.5.x Follow-up

Labels: documentation, v0.5.x, discussion-needed