### PR TITLE
Add v0.5.x principal context testing CSV refinement proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a temporary v0.5.x principal context testing CSV refinement proposal.
 - Added a temporary v0.5.x principal context testing candidate appendix.
 - Added a temporary v0.5.x principal context testing proposal for the first testing incorporation batch.
 - Added a temporary v0.5.x testing incorporation readiness review for selected testing candidates.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │           ├── v050x-testing-draft-pass-fail-criteria.md
 │           ├── v050x-testing-incorporation-readiness-review.md
 │           ├── v050x-principal-context-testing-proposal.md
-│           └── v050x-principal-context-testing-candidate-appendix.md
+│           ├── v050x-principal-context-testing-candidate-appendix.md
+│           └── v050x-principal-context-testing-csv-refinement-proposal.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -40,6 +40,8 @@ For v0.5.x principal context testing proposal, see `docs/en/status/v050x-princip
 
 For v0.5.x principal context testing candidate appendix, see `docs/en/status/v050x-principal-context-testing-candidate-appendix.md`.
 
+For v0.5.x principal context testing CSV refinement proposal, see `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md`.
+
 ## Research Motivation
 
 AAEF focuses on a specific problem in agentic AI assurance:

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -140,6 +140,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-testing-incorporation-readiness-review.md` | v0.5.x testing incorporation readiness review | Temporary status / coordination material |
 | `docs/en/status/v050x-principal-context-testing-proposal.md` | v0.5.x principal context testing proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-principal-context-testing-candidate-appendix.md` | v0.5.x principal context testing candidate appendix | Temporary status / coordination material |
+| `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md` | v0.5.x principal context testing CSV refinement proposal | Temporary status / coordination material |
 
 ## Physical Organization Policy
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -50,3 +50,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - `docs/en/status/v050x-testing-incorporation-readiness-review.md`
 - `docs/en/status/v050x-principal-context-testing-proposal.md`
 - `docs/en/status/v050x-principal-context-testing-candidate-appendix.md`
+- `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md`

--- a/docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md
+++ b/docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md
@@ -1,0 +1,185 @@
+# v0.5.x Principal Context Testing CSV Refinement Proposal
+
+**Status:** Temporary, non-normative CSV refinement proposal
+
+## Purpose
+
+This document records the proposed path for incorporating principal context testing candidates into active testing artifacts.
+
+It follows:
+
+- `docs/en/status/v050x-principal-context-testing-candidate-appendix.md`
+- `docs/en/status/v050x-principal-context-testing-proposal.md`
+- `docs/en/status/v050x-testing-incorporation-readiness-review.md`
+- `docs/en/status/v050x-testing-draft-pass-fail-criteria.md`
+- `docs/en/status/v050x-testing-candidate-mapping.md`
+- `docs/en/status/v050x-incorporation-decision-register.md`
+
+This document does not change the v0.4.1 control and assessment baseline.
+
+It does not update the active testing procedure CSV.
+
+It does not create executable fixtures.
+
+## Current Testing CSV Constraint
+
+The active testing procedure draft is:
+
+- `assessment/aaef-testing-procedures-v0.4-draft.csv`
+
+The current testing procedure validator expects testing procedure rows to match the control catalog one-to-one.
+
+Therefore, temporary VTC candidate IDs should not be added directly to the active testing procedure CSV unless a later change explicitly updates the testing model, validator, and related documentation.
+
+## Decision
+
+Do not add `VTC-PCD-*` rows directly to the active testing procedure CSV at this stage.
+
+Instead, treat the principal context candidates as refinement inputs for existing AUZ testing rows.
+
+This avoids:
+
+- breaking one-to-one validation with the control catalog;
+- turning temporary VTC IDs into apparent active requirements;
+- changing the active baseline before reviewer agreement;
+- mixing candidate tests with current control-linked testing procedures.
+
+## Candidate-to-Active-Row Mapping
+
+| Candidate | Primary existing row | Secondary existing rows | Proposed incorporation path |
+| --- | --- | --- | --- |
+| VTC-PCD-02 Scope Expansion Accepted | AAEF-AUZ-02 | AAEF-AUZ-08, AAEF-AUZ-09, AAEF-TOOL-04 | Refine sampling, pass, partial, or fail language for requested-vs-authorized scope and scope expansion before execution. |
+| VTC-PCD-03 Risk Escalation Ignored | AAEF-AUZ-07 | AAEF-AUZ-03, AAEF-AUZ-05, AAEF-AUZ-08 | Refine state/risk escalation testing language where risk changes before execution. |
+| VTC-PCD-04 Revoked or Downscoped Principal Context Accepted | AAEF-AUZ-07 | AAEF-AUZ-08, AAEF-AUZ-09 | Refine runtime state and revocation/downscope testing language. |
+| VTC-PCD-07 Untrusted Input Changes Principal Intent | AAEF-AUZ-05 | AAEF-AUZ-06, AAEF-AUZ-08, AAEF-TOOL-04, AAEF-EVD-05 | Refine untrusted input influence testing language and evidence expectations. |
+
+## Minimal First CSV Refinement Candidate
+
+The smallest active CSV refinement candidate should be limited to:
+
+- VTC-PCD-02 mapped primarily to `AAEF-AUZ-02`
+- VTC-PCD-04 mapped primarily to `AAEF-AUZ-07`
+
+These two are the most concrete and least dependent on unresolved threshold definitions.
+
+## Proposed AAEF-AUZ-02 Refinement Direction
+
+### Current concern
+
+`AAEF-AUZ-02` already covers requested purpose and target resource mismatch.
+
+However, the principal context testing work indicates that scope expansion should be explicitly visible in testing language.
+
+### Proposed refinement area
+
+Potential future refinements may clarify that samples should include, where feasible:
+
+- originally authorized scope;
+- later requested or executed scope;
+- target, tenant, resource, dataset, environment, or operation expansion;
+- comparison between authorized and requested scope;
+- denial, deferral, escalation, limitation, or reauthorization before execution.
+
+### Candidate impact
+
+This would incorporate the core of VTC-PCD-02 without adding a new testing row.
+
+## Proposed AAEF-AUZ-07 Refinement Direction
+
+### Current concern
+
+`AAEF-AUZ-07` already covers material runtime state and includes revocation state.
+
+However, the principal context testing work indicates that revoked, expired, or downscoped principal context should be explicit in testing language.
+
+### Proposed refinement area
+
+Potential future refinements may clarify that samples should include, where feasible:
+
+- authority revocation;
+- authority expiry;
+- downscoped entitlement or authority;
+- runtime state change affecting execution eligibility;
+- state check timestamp or trusted state source;
+- denial, freeze, escalation, limitation, or reauthorization before execution.
+
+### Candidate impact
+
+This would incorporate the core of VTC-PCD-04 without adding a new testing row.
+
+## Candidates Not Recommended for Immediate CSV Refinement
+
+### VTC-PCD-03 — Risk Escalation Ignored
+
+This candidate should remain close, but may require clearer wording around:
+
+- risk tier definitions;
+- high-impact transition thresholds;
+- relationship to `AAEF-AUZ-03`;
+- relationship to assessment profiles.
+
+### VTC-PCD-07 — Untrusted Input Changes Principal Intent
+
+This candidate should remain close, but may require clearer wording around:
+
+- material untrusted input influence;
+- input source classification;
+- trusted principal intent;
+- relationship to `AAEF-AUZ-05`;
+- relationship to `AAEF-TOOL-04` and evidence expectations.
+
+## Proposed Next Active CSV PR
+
+A later active CSV PR, if approved, should be narrow.
+
+Recommended initial scope:
+
+- refine only `AAEF-AUZ-02`;
+- refine only `AAEF-AUZ-07`;
+- do not add new rows;
+- do not add VTC IDs to active CSV;
+- update only testing language, not control requirements;
+- validate the one-to-one testing procedure model remains intact.
+
+## Review Questions Before Active CSV Change
+
+Before editing the active testing procedure CSV, reviewers should answer:
+
+- Should VTC-PCD-02 be incorporated into `AAEF-AUZ-02`, `AAEF-AUZ-08`, or both?
+- Should VTC-PCD-04 be incorporated into `AAEF-AUZ-07`, `AAEF-AUZ-08`, or both?
+- Should scope expansion and revocation/downscope be sample selection refinements, pass criteria refinements, fail condition refinements, or all three?
+- Would the refinements materially change control expectations, or only clarify testing?
+- Should the changelog describe the next change as testing refinement rather than a new testing requirement?
+- Should #161 remain open after the first CSV refinement because task drift, retry, and task splitting remain unresolved?
+
+## Relationship to #161
+
+This document supports #161 by identifying a safe path from principal context testing candidates toward active testing procedure refinement.
+
+It does not close #161.
+
+Remaining #161 work includes:
+
+- deciding whether to refine active testing CSV rows;
+- deciding whether VTC-PCD-03 and VTC-PCD-07 are ready for later refinement;
+- defining material task drift thresholds;
+- defining retry-after-denial correlation;
+- defining task splitting and aggregate-effect bypass criteria;
+- deciding whether related evidence/schema candidates are needed.
+
+## Non-Goals
+
+This document does not:
+
+- update testing procedure CSV;
+- add active testing procedure rows;
+- add VTC IDs to active CSV;
+- create executable fixtures;
+- add control IDs;
+- change the control catalog;
+- change the evidence schema;
+- change assessment profiles;
+- close #161;
+- change the one-to-one testing procedure model.
+
+It is a temporary CSV refinement proposal for the v0.5.x incorporation phase.


### PR DESCRIPTION
## Summary

This PR adds a temporary v0.5.x principal context testing CSV refinement proposal.

Changes include:

- Add `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md`
- Record that VTC candidate IDs should not be added directly to the active testing procedure CSV
- Explain the current one-to-one testing procedure model
- Map selected principal context testing candidates to existing AUZ-focused testing rows
- Identify VTC-PCD-02 and VTC-PCD-04 as the smallest initial active CSV refinement candidates
- Propose refinement directions for AAEF-AUZ-02 and AAEF-AUZ-07
- Clarify that this does not update testing procedure CSV or active baseline artifacts
- Link the proposal from the status directory README, document map, README repository tree, and researcher overview
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a non-normative status and coordination update.

It does not:

- update testing procedure CSV
- add active testing procedure rows
- add VTC IDs to active CSV
- create executable fixtures
- add new control IDs
- change the current baseline
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- change evidence schema
- change evidence examples
- close #161

## Related

Related follow-up issue:

- #161

Related testing candidate documents:

- `docs/en/status/v050x-principal-context-testing-candidate-appendix.md`
- `docs/en/status/v050x-principal-context-testing-proposal.md`
- `docs/en/status/v050x-testing-incorporation-readiness-review.md`
- `docs/en/status/v050x-testing-draft-pass-fail-criteria.md`
- `docs/en/status/v050x-testing-candidate-mapping.md`

Related incorporation register:

- `docs/en/status/v050x-incorporation-decision-register.md`

Milestone: v0.5.x Follow-up

Labels: documentation, testing, evidence, v0.5.x, discussion-needed