### PR TITLE
Update v0.5.x status after principal context testing refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Updated v0.5.x status documents after the principal context testing procedure refinement.
 - Refined `AAEF-AUZ-02` and `AAEF-AUZ-07` testing procedure language for scope expansion and authority lifecycle state changes.
 
 ### Added

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -114,3 +114,22 @@ This document does not:
 - replace release notes;
 - replace the document map;
 - define new control, testing, evidence, assessment, or schema requirements.
+
+## Update after #189
+
+PR #189 partially incorporated the principal context degradation testing work into active testing procedures.
+
+The active testing procedure CSV was refined for:
+
+- `AAEF-AUZ-02` — requested purpose, target resource, and applicable scope, including material scope expansion;
+- `AAEF-AUZ-07` — material runtime state, including revocation, expiry, downscoping, and authority lifecycle state changes.
+
+This update partially addresses #161.
+
+#161 remains open because additional principal context degradation work is still pending, including:
+
+- material task drift thresholds;
+- retry-after-denial correlation;
+- task splitting and aggregate-effect bypass criteria;
+- whether VTC-PCD-03 and VTC-PCD-07 require additional active testing refinement;
+- whether related evidence, schema, or assessment profile changes are needed.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -332,3 +332,28 @@ This document does not:
 - supersede release notes.
 
 It is a temporary decision register for the v0.5.x incorporation phase.
+
+## Incorporation Update after #189
+
+PR #189 completed the first active testing procedure refinement based on the principal context testing candidate work.
+
+The refinement did not add temporary `VTC-PCD-*` rows to the active testing procedure CSV.
+
+Instead, it preserved the one-control-one-row testing model and refined existing active rows:
+
+- `AAEF-AUZ-02` for material scope expansion and requested-vs-authorized scope review;
+- `AAEF-AUZ-07` for revocation, expiry, downscoping, and authority lifecycle state changes.
+
+This confirms the selected incorporation path for the first #161 batch:
+
+- use VTC candidates as planning and review inputs;
+- refine existing control-linked testing rows where appropriate;
+- avoid promoting temporary VTC IDs into active testing artifacts unless the testing model is explicitly changed.
+
+Remaining #161-related incorporation decisions include:
+
+- whether and how to incorporate task drift tests;
+- whether and how to incorporate retry-after-denial tests;
+- whether and how to incorporate task splitting and aggregate-effect bypass tests;
+- whether risk escalation and untrusted input influence require additional active testing refinement;
+- whether related evidence/schema or assessment profile changes are needed.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after the principal context testing procedure refinement in #189.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Record that #189 partially incorporated #161 into active testing procedures
- Record that `AAEF-AUZ-02` and `AAEF-AUZ-07` were refined
- Clarify that #161 remains open
- Record remaining #161 work, including task drift, retry-after-denial, task splitting / aggregate-effect bypass, and possible evidence/schema/profile decisions
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a status documentation update.

It does not:

- update testing procedure CSV
- add testing procedure rows
- add VTC IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- change evidence schema
- change evidence examples
- close #161

## Related

Related PR:

- #189

Related follow-up issue:

- #161

Milestone: v0.5.x Follow-up

Labels: documentation, testing, v0.5.x