### PR TITLE
Update v0.5.x status after cross-agent delegation testing refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Updated v0.5.x status documents after the cross-agent delegation testing procedure refinement.
 - Refined `AAEF-DEL-01` and `AAEF-DEL-05` testing procedure language for cross-agent delegation authority validation.
 
 ### Added

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -133,3 +133,23 @@ This update partially addresses #161.
 - task splitting and aggregate-effect bypass criteria;
 - whether VTC-PCD-03 and VTC-PCD-07 require additional active testing refinement;
 - whether related evidence, schema, or assessment profile changes are needed.
+
+## Update after #194
+
+PR #194 partially incorporated the cross-agent delegation testing work into active testing procedures.
+
+The active testing procedure CSV was refined for:
+
+- `AAEF-DEL-01` — delegated scope mismatch, delegated capability, operation, target, resource, and downstream action comparison;
+- `AAEF-DEL-05` — cross-agent authority lineage, communication-not-authority handling, and receiving-side validation evidence.
+
+This update partially addresses #163.
+
+#163 remains open because additional cross-agent delegation work is still pending, including:
+
+- capability-scoped delegation refinement for `AAEF-DEL-02`;
+- fire-and-forget delegation and explicit acceptance behavior;
+- refusal propagation and resulting workflow state evidence;
+- downstream redelegation authority;
+- minimum delegation chain evidence expectations;
+- whether related evidence, schema, control, or assessment profile changes are needed.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -357,3 +357,29 @@ Remaining #161-related incorporation decisions include:
 - whether and how to incorporate task splitting and aggregate-effect bypass tests;
 - whether risk escalation and untrusted input influence require additional active testing refinement;
 - whether related evidence/schema or assessment profile changes are needed.
+
+## Incorporation Update after #194
+
+PR #194 completed the first active testing procedure refinement based on the cross-agent delegation testing candidate work.
+
+The refinement did not add temporary `VTC-A2A-*` rows to the active testing procedure CSV.
+
+Instead, it preserved the one-control-one-row testing model and refined existing active rows:
+
+- `AAEF-DEL-01` for delegated scope mismatch and delegated capability, operation, target, or resource comparison;
+- `AAEF-DEL-05` for cross-agent authority lineage, communication-not-authority handling, and receiving-side validation.
+
+This confirms the selected incorporation path for the first #163 batch:
+
+- use VTC candidates as planning and review inputs;
+- refine existing control-linked testing rows where appropriate;
+- avoid promoting temporary VTC IDs into active testing artifacts unless the testing model is explicitly changed.
+
+Remaining #163-related incorporation decisions include:
+
+- whether and how to refine `AAEF-DEL-02` for capability-scoped delegation;
+- whether and how to incorporate fire-and-forget delegation tests;
+- whether and how to incorporate refusal propagation tests;
+- whether downstream redelegation requires new active testing language;
+- whether minimum delegation chain evidence expectations require additional refinement;
+- whether related evidence/schema, control catalog, or assessment profile changes are needed.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after the cross-agent delegation testing procedure refinement in #194.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Record that #194 partially incorporated #163 into active testing procedures
- Record that `AAEF-DEL-01` and `AAEF-DEL-05` were refined
- Clarify that #163 remains open
- Record remaining #163 work, including capability-scoped delegation refinement, fire-and-forget delegation, refusal propagation, downstream redelegation, chain evidence expectations, and possible evidence/schema/profile decisions
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a status documentation update.

It does not:

- update testing procedure CSV
- add testing procedure rows
- add VTC IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- change evidence schema
- change evidence examples
- close #163

## Related

Related PR:

- #194

Related follow-up issue:

- #163

Milestone: v0.5.x Follow-up

Labels: documentation, testing, v0.5.x