### PR TITLE
Update v0.5.x status after approval quality testing refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Updated v0.5.x status documents after the approval quality testing procedure refinement.
 - Refined `AAEF-HUM-01` and `AAEF-AUZ-03` testing procedure language for approval quality and approval-to-execution binding.
 
 ### Added

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -153,3 +153,23 @@ This update partially addresses #163.
 - downstream redelegation authority;
 - minimum delegation chain evidence expectations;
 - whether related evidence, schema, control, or assessment profile changes are needed.
+
+## Update after #199
+
+PR #199 partially incorporated the approval quality testing work into active testing procedures.
+
+The active testing procedure CSV was refined for:
+
+- `AAEF-HUM-01` — what the approver actually saw, vague approval prompt handling, and action-bound approval context;
+- `AAEF-AUZ-03` — canonical action matching, approval scope, approval state source, and independent approval enforcement before execution.
+
+This update partially addresses #167.
+
+#167 remains open because additional approval quality work is still pending, including:
+
+- draft-vs-execute approval operation-class refinement;
+- post-approval payload modification and materiality criteria;
+- model-generated approval summary treatment as evidence;
+- trusted approval evidence source expectations;
+- approval fatigue and repeated approval interaction with HUM-02;
+- whether related evidence, schema, control, or assessment profile changes are needed.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -383,3 +383,29 @@ Remaining #163-related incorporation decisions include:
 - whether downstream redelegation requires new active testing language;
 - whether minimum delegation chain evidence expectations require additional refinement;
 - whether related evidence/schema, control catalog, or assessment profile changes are needed.
+
+## Incorporation Update after #199
+
+PR #199 completed the first active testing procedure refinement based on the approval quality testing candidate work.
+
+The refinement did not add temporary `VTC-APP-*` rows to the active testing procedure CSV.
+
+Instead, it preserved the one-control-one-row testing model and refined existing active rows:
+
+- `AAEF-HUM-01` for meaningful approval context, what the approver actually saw, vague approval prompt handling, and approval-to-action linkage;
+- `AAEF-AUZ-03` for canonical action matching, approved scope, approval state source, and independent approval enforcement before dispatch or backend execution.
+
+This confirms the selected incorporation path for the first #167 batch:
+
+- use VTC candidates as planning and review inputs;
+- refine existing control-linked testing rows where appropriate;
+- avoid promoting temporary VTC IDs into active testing artifacts unless the testing model is explicitly changed.
+
+Remaining #167-related incorporation decisions include:
+
+- whether and how to incorporate draft-vs-execute approval operation-class tests;
+- whether and how to incorporate post-approval payload modification tests;
+- whether and how to incorporate model-generated approval summary evidence tests;
+- whether approval evidence trusted-source expectations require `AAEF-EVD-03` refinement;
+- whether approval fatigue and repeated approval behavior require additional `AAEF-HUM-02` refinement;
+- whether related evidence/schema, control catalog, or assessment profile changes are needed.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after the approval quality testing procedure refinement in #199.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Record that #199 partially incorporated #167 into active testing procedures
- Record that `AAEF-HUM-01` and `AAEF-AUZ-03` were refined
- Clarify that #167 remains open
- Record remaining #167 work, including draft-vs-execute approval, post-approval payload modification, model-generated approval summary evidence, trusted approval evidence source expectations, approval fatigue, and possible evidence/schema/profile decisions
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a status documentation update.

It does not:

- update testing procedure CSV
- add testing procedure rows
- add VTC IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- change evidence schema
- change evidence examples
- close #167

## Related

Related PR:

- #199

Related follow-up issue:

- #167

Milestone: v0.5.x Follow-up

Labels: documentation, testing, v0.5.x