### PR TITLE
Update v0.5.x status after evidence integrity review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated v0.5.x status documents after the evidence integrity CSV refinement proposal review.
+
 ### Added
 
 - Added a temporary v0.5.x evidence integrity CSV refinement proposal.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -173,3 +173,26 @@ This update partially addresses #167.
 - trusted approval evidence source expectations;
 - approval fatigue and repeated approval interaction with HUM-02;
 - whether related evidence, schema, control, or assessment profile changes are needed.
+
+## Update after #201
+
+PR #201 added the evidence integrity CSV refinement proposal.
+
+The review determined that the first evidence integrity incorporation step does not require an immediate active testing procedure CSV change.
+
+The existing active testing procedure row already provides substantial coverage:
+
+- `AAEF-EVD-04` — critical and audit-grade evidence integrity, tamper-evident protection, append-only or write-restricted storage, cryptographic linkage, independent corroboration, deletion/redaction handling, replay, reordering, truncation, selective omission, and evidence trust limitations.
+
+This update records #165 as already substantially represented in the current active testing procedure model through `AAEF-EVD-04`.
+
+#165 remains open because additional evidence integrity work is still pending, including:
+
+- deciding whether evidence integrity fields should be added to the Evidence Event Schema;
+- defining E5 or higher-depth examples using tamper-evident evidence;
+- defining minimum integrity expectations by evidence depth or action risk;
+- defining negative tests for evidence tampering, deletion, replay, reordering, truncation, and selective omission;
+- defining evidence replay tests;
+- defining selective omission tests;
+- defining incident-response evidence preservation guidance;
+- deciding whether a later minor `AAEF-EVD-04` wording refinement is needed.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -409,3 +409,47 @@ Remaining #167-related incorporation decisions include:
 - whether approval evidence trusted-source expectations require `AAEF-EVD-03` refinement;
 - whether approval fatigue and repeated approval behavior require additional `AAEF-HUM-02` refinement;
 - whether related evidence/schema, control catalog, or assessment profile changes are needed.
+
+## Incorporation Update after #201
+
+PR #201 completed the evidence integrity CSV refinement proposal review.
+
+The review concluded that immediate active testing procedure CSV refinement is not required for the first #165 incorporation step.
+
+The current active testing procedure row `AAEF-EVD-04` already covers the primary evidence integrity and tamper-evident evidence requirements, including:
+
+- critical and audit-grade evidence;
+- undetected alteration;
+- deletion;
+- replay;
+- reordering;
+- truncation;
+- selective omission;
+- integrity verification;
+- append-only evidence storage;
+- write-restricted evidence stores;
+- signed evidence records;
+- hash chains;
+- Merkle roots;
+- external timestamps;
+- immutable storage policies;
+- independent corroborating logs;
+- retention policy;
+- deletion or redaction records;
+- evidence trust limitations.
+
+This confirms the selected incorporation path for the first #165 batch:
+
+- do not add temporary evidence integrity candidate IDs to active testing artifacts;
+- do not create new control IDs at this stage;
+- use `AAEF-EVD-04` as the central active row for evidence integrity and tamper-evident evidence;
+- defer schema, examples, negative tests, and incident-response preservation details to follow-up work.
+
+Remaining #165-related incorporation decisions include:
+
+- whether evidence integrity fields should be added to the Evidence Event Schema;
+- whether E5 or higher-depth evidence examples should be introduced;
+- whether negative tests should be added for tampering, deletion, replay, reordering, truncation, and selective omission;
+- whether incident-response evidence preservation guidance should be created or refined;
+- whether `AAEF-EVD-04` should receive a later minor wording refinement for verification result and failure handling;
+- whether evidence integrity should be tied to assessment profiles or evidence depth levels.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after the evidence integrity CSV refinement proposal in #201.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Record that #201 determined no immediate active testing procedure CSV change is required for the first #165 incorporation step
- Record that existing `AAEF-EVD-04` coverage already substantially represents evidence integrity and tamper-evident evidence requirements
- Clarify that #165 remains open
- Record remaining #165 work, including evidence schema fields, E5 or higher-depth examples, negative tests, evidence replay tests, selective omission tests, and incident-response evidence preservation guidance
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a status documentation update.

It does not:

- update testing procedure CSV
- add testing procedure rows
- add temporary candidate IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- change evidence schema
- change evidence examples
- close #165

## Related

Related PR:

- #201

Related follow-up issue:

- #165

Related active row:

- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, testing, evidence, v0.5.x