### PR TITLE
Add v0.5.x incorporation review checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added a temporary v0.5.x incorporation review checkpoint for #161, #163, #165, and #167.
+
 ### Changed
 
 - Updated v0.5.x status documents after the evidence integrity CSV refinement proposal review.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,8 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │           ├── v050x-approval-quality-testing-proposal.md
 │           ├── v050x-approval-quality-testing-candidate-appendix.md
 │           ├── v050x-approval-quality-csv-refinement-proposal.md
-│           └── v050x-evidence-integrity-csv-refinement-proposal.md
+│           ├── v050x-evidence-integrity-csv-refinement-proposal.md
+│           └── v050x-incorporation-review-checkpoint.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -56,6 +56,8 @@ For v0.5.x approval quality CSV refinement proposal, see `docs/en/status/v050x-a
 
 For v0.5.x evidence integrity CSV refinement proposal, see `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md`.
 
+For the v0.5.x incorporation review checkpoint, see `docs/en/status/v050x-incorporation-review-checkpoint.md`.
+
 ## Research Motivation
 
 AAEF focuses on a specific problem in agentic AI assurance:

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -148,6 +148,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` | v0.5.x approval quality testing candidate appendix | Temporary status / coordination material |
 | `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` | v0.5.x approval quality CSV refinement proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md` | v0.5.x evidence integrity CSV refinement proposal | Temporary status / coordination material |
+| `docs/en/status/v050x-incorporation-review-checkpoint.md` | v0.5.x incorporation review checkpoint | Temporary status / coordination material |
 
 ## Physical Organization Policy
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -58,3 +58,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md`
 - `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md`
 - `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md`
+- `docs/en/status/v050x-incorporation-review-checkpoint.md`

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -196,3 +196,18 @@ This update records #165 as already substantially represented in the current act
 - defining selective omission tests;
 - defining incident-response evidence preservation guidance;
 - deciding whether a later minor `AAEF-EVD-04` wording refinement is needed.
+
+## Checkpoint after #202
+
+After #202, the first incorporation review cycle for #161, #163, #165, and #167 is complete.
+
+Current checkpoint:
+
+- #161 principal context — first active CSV refinement incorporated; issue remains open.
+- #163 cross-agent delegation — first active CSV refinement incorporated; issue remains open.
+- #165 evidence integrity — substantially represented by existing `AAEF-EVD-04`; no immediate active CSV change required; issue remains open.
+- #167 approval quality — first active CSV refinement incorporated; issue remains open.
+
+For the consolidated checkpoint, see `docs/en/status/v050x-incorporation-review-checkpoint.md`.
+
+The next phase should split remaining work into smaller tracks for evidence schema and examples, negative tests, delegation semantics, approval semantics, and cleanup/publication readiness.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -453,3 +453,26 @@ Remaining #165-related incorporation decisions include:
 - whether incident-response evidence preservation guidance should be created or refined;
 - whether `AAEF-EVD-04` should receive a later minor wording refinement for verification result and failure handling;
 - whether evidence integrity should be tied to assessment profiles or evidence depth levels.
+
+## Incorporation Review Checkpoint after #202
+
+After #202, the first incorporation review cycle for #161, #163, #165, and #167 is complete.
+
+The current incorporation decisions are:
+
+| Issue | Topic | Incorporation decision | Active artifact result | Status |
+| --- | --- | --- | --- | --- |
+| #161 | Principal context | Partially incorporate into existing active testing rows | Active testing procedure CSV refined | Open |
+| #163 | Cross-agent delegation | Partially incorporate into existing active DEL testing rows | Active testing procedure CSV refined | Open |
+| #165 | Evidence integrity | Treat as substantially represented by `AAEF-EVD-04` for the first step | No immediate active CSV change | Open |
+| #167 | Approval quality | Partially incorporate into existing active HUM/AUZ testing rows | Active testing procedure CSV refined | Open |
+
+The consolidated checkpoint is recorded in `docs/en/status/v050x-incorporation-review-checkpoint.md`.
+
+The next incorporation phase should focus on smaller follow-up decisions rather than broad first-pass incorporation:
+
+- evidence schema and examples;
+- evidence integrity negative tests;
+- delegation semantics;
+- approval semantics;
+- status document cleanup and publication readiness.

--- a/docs/en/status/v050x-incorporation-review-checkpoint.md
+++ b/docs/en/status/v050x-incorporation-review-checkpoint.md
@@ -1,0 +1,238 @@
+# v0.5.x Incorporation Review Checkpoint
+
+**Status:** Temporary, non-normative incorporation checkpoint
+
+## Purpose
+
+This document summarizes the v0.5.x incorporation review status after the first review cycle for selected follow-up issues.
+
+It consolidates the current state after review and incorporation decisions for:
+
+- #161 — principal context testing refinement;
+- #163 — cross-agent delegation testing refinement;
+- #165 — evidence integrity and tamper-evident evidence;
+- #167 — approval quality testing refinement.
+
+This document is a temporary coordination artifact.
+
+It does not change the active baseline.
+
+It does not update the control catalog.
+
+It does not update testing procedures.
+
+It does not update the evidence schema.
+
+It does not close any follow-up issue by itself.
+
+## Checkpoint Summary
+
+| Issue | Topic | First incorporation result | Active artifact impact | Current status |
+| --- | --- | --- | --- | --- |
+| #161 | Principal context degradation / principal context testing | Partially incorporated | Active testing procedure CSV refined | Open, remaining edge cases |
+| #163 | Cross-agent delegation testing | Partially incorporated | Active testing procedure CSV refined | Open, remaining delegation semantics |
+| #165 | Evidence integrity / tamper-evident evidence | Substantially represented by existing active row | No immediate active CSV change required | Open, schema/examples/tests remain |
+| #167 | Approval quality testing | Partially incorporated | Active testing procedure CSV refined | Open, remaining approval semantics |
+
+## Completed Incorporation Work
+
+### #161 — Principal Context
+
+The first principal context testing refinement cycle has been completed.
+
+Completed work includes:
+
+- proposal and candidate review;
+- active CSV refinement;
+- status reflection;
+- incorporation decision register update.
+
+The first active refinement focused on existing principal context testing language rather than adding temporary candidate IDs or new controls.
+
+Current state:
+
+- first active incorporation completed;
+- issue remains open;
+- future work remains around long-running workflows, reauthorization, delegation edge cases, schema/profile implications, and additional testing depth.
+
+### #163 — Cross-Agent Delegation
+
+The first cross-agent delegation testing refinement cycle has been completed.
+
+Completed work includes:
+
+- proposal and candidate appendix;
+- CSV refinement proposal;
+- active CSV refinement for selected DEL rows;
+- status reflection;
+- incorporation decision register update.
+
+The first active refinement preserved the one-control-one-row testing model.
+
+Current state:
+
+- first active incorporation completed;
+- issue remains open;
+- future work remains around capability-scoped delegation, fire-and-forget delegation, refusal propagation, downstream redelegation, minimum chain evidence, and possible schema/profile/control implications.
+
+### #165 — Evidence Integrity
+
+The first evidence integrity review cycle has been completed.
+
+Completed work includes:
+
+- CSV refinement proposal;
+- determination that no immediate active testing procedure CSV change is required for the first incorporation step;
+- status reflection;
+- incorporation decision register update.
+
+The review concluded that `AAEF-EVD-04` already substantially represents the core evidence integrity and tamper-evident evidence expectations.
+
+Current state:
+
+- first incorporation review completed;
+- no immediate active CSV change required;
+- issue remains open;
+- future work remains around evidence schema fields, E5 or higher-depth examples, negative tests, evidence replay tests, selective omission tests, and incident-response evidence preservation guidance.
+
+### #167 — Approval Quality
+
+The first approval quality testing refinement cycle has been completed.
+
+Completed work includes:
+
+- proposal and candidate appendix;
+- CSV refinement proposal;
+- active CSV refinement for selected HUM and AUZ rows;
+- status reflection;
+- incorporation decision register update.
+
+The first active refinement focused on meaningful approval context, what the approver actually saw, canonical action matching, approval scope, approval state source, and independent approval enforcement.
+
+Current state:
+
+- first active incorporation completed;
+- issue remains open;
+- future work remains around draft-vs-execute approval, post-approval payload modification, model-generated approval summary evidence, trusted approval evidence source expectations, approval fatigue, and possible schema/profile/control implications.
+
+## Active Testing Procedure Impact So Far
+
+The first incorporation cycle changed active testing procedures for selected topics only.
+
+Active CSV refinements have been made for:
+
+- principal context-related testing rows;
+- cross-agent delegation-related testing rows;
+- approval quality-related testing rows.
+
+No active CSV refinement was made for #165 because `AAEF-EVD-04` already provides substantial coverage for the first evidence integrity incorporation step.
+
+Temporary VTC-style candidate IDs were not added to the active testing procedure CSV.
+
+The one-control-one-row testing procedure model remains intact.
+
+## Remaining Work by Category
+
+### Testing Procedure Refinement
+
+Remaining testing-related work includes:
+
+- capability-scoped delegation refinement;
+- downstream redelegation tests;
+- fire-and-forget delegation tests;
+- refusal propagation tests;
+- draft-vs-execute approval tests;
+- post-approval payload modification tests;
+- approval fatigue and repeated approval behavior;
+- evidence replay, reordering, truncation, deletion, and selective omission negative tests.
+
+### Evidence Schema and Examples
+
+Remaining evidence-related work includes:
+
+- deciding whether evidence integrity fields belong in the Evidence Event Schema;
+- defining E5 or higher-depth tamper-evident evidence examples;
+- defining trusted approval evidence source expectations;
+- defining model-generated approval summary handling;
+- defining evidence trust limitations more precisely where needed.
+
+### Control Catalog and Profile Decisions
+
+No new control IDs were added in the first incorporation cycle.
+
+Remaining design questions include:
+
+- whether approval quality needs new dedicated control entries later;
+- whether cross-agent delegation needs additional controls for downstream redelegation or refusal propagation;
+- whether evidence integrity should be tied to assessment profiles or evidence depth levels;
+- whether principal context degradation requires profile-specific handling.
+
+### Status and Maintenance
+
+Temporary status documents remain useful while v0.5.x follow-up work is active.
+
+They may later be:
+
+- archived;
+- removed;
+- consolidated into stable documentation;
+- converted into active testing, schema, profile, or guidance changes;
+- replaced by issue-specific follow-up documents.
+
+## Recommended Next Phase
+
+The next phase should split remaining work into smaller follow-up tracks.
+
+Recommended tracks:
+
+1. Evidence schema and examples track
+   - evidence integrity fields;
+   - E5 evidence examples;
+   - tamper-evident evidence examples;
+   - trusted approval evidence source examples.
+
+2. Negative testing track
+   - evidence tampering;
+   - evidence deletion;
+   - evidence replay;
+   - evidence reordering;
+   - selective omission;
+   - approval bypass;
+   - delegation refusal propagation.
+
+3. Delegation semantics track
+   - capability-scoped delegation;
+   - downstream redelegation;
+   - fire-and-forget delegation;
+   - refusal propagation;
+   - minimum delegation chain evidence.
+
+4. Approval semantics track
+   - draft-vs-execute approval;
+   - post-approval modification;
+   - model-generated approval summaries;
+   - approval fatigue and repeated approval.
+
+5. Cleanup and publication-readiness track
+   - status document consolidation;
+   - document map review;
+   - follow-up issue triage;
+   - release note preparation.
+
+## Non-Goals
+
+This checkpoint does not:
+
+- update active testing procedure CSV;
+- add testing procedure rows;
+- add candidate IDs to active CSV;
+- change control catalog CSV;
+- change human-readable control requirements;
+- change assessment worksheet;
+- change assessment profiles;
+- change external framework mapping CSV;
+- change evidence schema;
+- change evidence examples;
+- close #161, #163, #165, or #167.
+
+It records the current incorporation review state after the first v0.5.x review cycle.


### PR DESCRIPTION
## Summary

This PR adds a temporary v0.5.x incorporation review checkpoint after the first incorporation review cycle for #161, #163, #165, and #167.

Changes include:

- Add `docs/en/status/v050x-incorporation-review-checkpoint.md`
- Summarize the current incorporation status for #161, #163, #165, and #167
- Record that #161, #163, and #167 have first active testing procedure refinements incorporated
- Record that #165 is substantially represented by existing `AAEF-EVD-04` and does not require immediate active CSV change
- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Link the checkpoint from the status directory README, document map, README repository tree, and researcher overview
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.
    OK: evidence schema and examples validated.

## Impact

This is a status documentation and coordination update.

It does not:

- update testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- change evidence schema
- change evidence examples
- close #161, #163, #165, or #167

## Related

Related follow-up issues:

- #161
- #163
- #165
- #167

Related PRs:

- #189
- #190
- #194
- #195
- #199
- #200
- #201
- #202

Milestone: v0.5.x Follow-up

Labels: documentation, testing, evidence, v0.5.x