### PR TITLE
Add optional evidence integrity and approval schema fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added optional Evidence Event Schema fields for evidence integrity, evidence trust limitations, approval evidence source, approval binding, and approval enforcement references.
 - Added a temporary v0.5.x evidence schema/example implementation readiness review.
 - Added a temporary v0.5.x evidence example design proposal.
 - Added a temporary v0.5.x evidence schema field proposal.

--- a/docs/en/status/v050x-evidence-schema-example-implementation-readiness.md
+++ b/docs/en/status/v050x-evidence-schema-example-implementation-readiness.md
@@ -287,3 +287,15 @@ This readiness review does not:
 - close #161, #163, #165, or #167.
 
 It records readiness decisions before the first actual schema or example implementation PR.
+
+## Schema Implementation Progress
+
+The first implementation PR for this track adds optional Evidence Event Schema support for:
+
+- evidence integrity metadata;
+- evidence trust limitations;
+- approval evidence source references;
+- approval-to-action binding references;
+- execution-bound approval enforcement references.
+
+This implementation keeps the new schema fields optional and does not add evidence examples in the same change.

--- a/docs/en/status/v050x-evidence-schema-field-proposal.md
+++ b/docs/en/status/v050x-evidence-schema-field-proposal.md
@@ -315,3 +315,11 @@ The proposal focuses on two candidate examples:
 - `agentic-action-evidence-event.approval-binding.json`
 
 The examples are design candidates only and do not modify the active schema or example files.
+
+## First Schema Implementation
+
+The first schema implementation uses the narrow optional field approach described in this proposal.
+
+It adds optional schema support for evidence integrity, evidence trust limitation, approval evidence source, approval-to-action binding, and execution-bound approval enforcement references.
+
+Principal context freshness and delegation lineage fields remain deferred.

--- a/schemas/agentic-action-evidence-event.schema.json
+++ b/schemas/agentic-action-evidence-event.schema.json
@@ -427,6 +427,78 @@
             "type": "string"
           },
           "description": "Information shown to the human approver."
+        },
+        "source_type": {
+          "type": "string",
+          "description": "Type of approval evidence source, such as workflow, ticket, policy engine, model summary, agent self-report, or external system."
+        },
+        "source_system": {
+          "type": "string",
+          "description": "System or workflow that produced the approval evidence."
+        },
+        "workflow_record_id": {
+          "type": "string",
+          "description": "Reference to the approval workflow record."
+        },
+        "trusted_source": {
+          "type": "boolean",
+          "description": "Whether the approval evidence source is treated as trusted for assessment purposes."
+        },
+        "context_presented_ref": {
+          "type": "string",
+          "description": "Reference to the action-bound context presented to the approver."
+        },
+        "approver_view_ref": {
+          "type": "string",
+          "description": "Reference to the approval UI, prompt, ticket, or review surface shown to the approver."
+        },
+        "canonical_action_id": {
+          "type": "string",
+          "description": "Canonical action identifier approved by the approval workflow."
+        },
+        "action_digest": {
+          "type": "string",
+          "description": "Digest or hash representing the approved action."
+        },
+        "approved_scope": {
+          "description": "Scope approved by the approval workflow.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": true
+            }
+          ]
+        },
+        "approved_operation_class": {
+          "type": "string",
+          "description": "Operation class approved by the workflow, such as draft, preview, execute, publish, send, delete, or spend."
+        },
+        "enforcement_check_id": {
+          "type": "string",
+          "description": "Reference to the execution-bound approval enforcement check."
+        },
+        "enforcement_result": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "deny",
+            "defer",
+            "escalate",
+            "not_checked",
+            "not_applicable"
+          ],
+          "description": "Result of the approval enforcement check before execution."
+        },
+        "checked_at_execution_boundary": {
+          "type": "boolean",
+          "description": "Whether approval state and scope were checked at the execution boundary before execution."
+        },
+        "model_summary_trusted_as_evidence": {
+          "type": "boolean",
+          "description": "Whether a model-generated approval summary was treated as trusted approval evidence."
         }
       }
     },
@@ -588,6 +660,76 @@
         "privacy_notes": {
           "type": "string",
           "description": "Notes on privacy-preserving storage, redaction, minimization, or access control."
+        },
+        "evidence_integrity": {
+          "type": "object",
+          "description": "Optional integrity metadata for evidence records or referenced evidence packages.",
+          "additionalProperties": false,
+          "properties": {
+            "protected": {
+              "type": "boolean",
+              "description": "Whether the evidence record or referenced evidence package is protected by an integrity mechanism."
+            },
+            "mechanism": {
+              "type": "string",
+              "description": "Integrity mechanism summary, such as append-only, write-restricted, signature, hash-chain, merkle-tree, immutable-storage, external-anchor, independent-corroboration, or equivalent."
+            },
+            "storage_class": {
+              "type": "string",
+              "description": "Storage or retention class relevant to the integrity mechanism."
+            },
+            "coverage": {
+              "type": "string",
+              "description": "Description or reference identifying what evidence scope the integrity mechanism covers."
+            },
+            "verification_result": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "fail",
+                "not_checked",
+                "partial",
+                "unavailable",
+                "not_applicable"
+              ],
+              "description": "Result of evidence integrity verification when available."
+            },
+            "verified_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Timestamp when integrity verification was performed."
+            },
+            "verification_error": {
+              "type": "string",
+              "description": "Error or limitation observed during integrity verification."
+            },
+            "verification_ref": {
+              "type": "string",
+              "description": "Reference to the verification event, job, record, or report."
+            },
+            "proof_ref": {
+              "type": "string",
+              "description": "Reference to an integrity proof, such as a signature, hash chain, Merkle proof, immutable-storage proof, or external anchor."
+            },
+            "external_anchor_ref": {
+              "type": "string",
+              "description": "Reference to an external timestamp, ledger, archive, or corroborating anchor."
+            }
+          }
+        },
+        "evidence_trust_limitation": {
+          "description": "Optional statement or list describing known limitations of the evidence source, completeness, independence, or verifiability.",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

This PR adds optional Evidence Event Schema fields for evidence integrity and approval evidence.

Changes include:

- Update `schemas/agentic-action-evidence-event.schema.json`
- Add optional evidence integrity metadata under `$defs/evidence`
- Add optional evidence trust limitation support under `$defs/evidence`
- Add optional approval evidence source fields under `$defs/approval`
- Add optional approval-to-action binding fields under `$defs/approval`
- Add optional execution-bound approval enforcement reference fields under `$defs/approval`
- Keep all new fields optional
- Do not add evidence examples in this PR
- Update the evidence schema field proposal and implementation readiness review
- Add an Unreleased changelog entry

## Validation

Validated locally:

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a schema extension with optional fields only.

It changes:

- `schemas/agentic-action-evidence-event.schema.json`

It does not:

- add required schema fields
- add evidence examples
- update testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, or #167

## Related

Related follow-up issues:

- #165
- #167
- #161
- #163

Related planning documents:

- `docs/en/status/v050x-evidence-schema-field-proposal.md`
- `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md`
- `docs/en/status/v050x-evidence-example-design-proposal.md`

Milestone: v0.5.x Follow-up

Labels: schema, evidence, v0.5.x, discussion-needed