### PR TITLE
Add approval binding evidence example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added an approval-binding evidence example using optional approval source, approval binding, and enforcement fields.
 - Added an integrity-focused evidence example using optional evidence integrity and trust limitation fields.
 - Added optional Evidence Event Schema fields for evidence integrity, evidence trust limitations, approval evidence source, approval binding, and approval enforcement references.
 - Added a temporary v0.5.x evidence schema/example implementation readiness review.

--- a/docs/en/status/v050x-evidence-example-design-proposal.md
+++ b/docs/en/status/v050x-evidence-example-design-proposal.md
@@ -344,3 +344,11 @@ The first example implementation adds `examples/agentic-action-evidence-event.in
 The example demonstrates optional evidence integrity metadata, integrity verification result, proof reference, external anchor reference, and evidence trust limitations.
 
 It does not add approval-binding evidence and does not change the Evidence Event Schema.
+
+## Approval Binding Example Implementation
+
+The second example implementation adds `examples/agentic-action-evidence-event.approval-binding.json`.
+
+The example demonstrates trusted approval evidence source, approval-to-action binding, approved scope, approved operation class, execution-bound approval enforcement, and explicit treatment of model-generated summaries as non-trusted approval evidence.
+
+It does not change the Evidence Event Schema.

--- a/docs/en/status/v050x-evidence-schema-example-implementation-readiness.md
+++ b/docs/en/status/v050x-evidence-schema-example-implementation-readiness.md
@@ -309,3 +309,13 @@ The first example PR adds the tamper-evident / integrity-verifiable evidence exa
 This follows the planned schema-first, example-follow-up approach.
 
 The approval-to-execution binding example remains pending.
+
+## Approval Binding Example Implementation Progress
+
+The second example PR adds the approval-to-execution binding evidence example:
+
+- `examples/agentic-action-evidence-event.approval-binding.json`
+
+This follows the planned schema-first, example-follow-up approach.
+
+The example demonstrates trusted approval source, approval binding, approval scope, and execution-bound approval enforcement using optional schema fields.

--- a/examples/agentic-action-evidence-event.approval-binding.json
+++ b/examples/agentic-action-evidence-event.approval-binding.json
@@ -1,0 +1,246 @@
+{
+  "schema": "aaef.agentic_action_evidence_event",
+  "schema_version": "0.2.0-draft",
+  "action_id": "act_approval_binding_001",
+  "timestamp": "2026-04-30T01:00:00Z",
+  "event_type": "agentic_action_executed",
+  "agent": {
+    "agent_id": "agent.procurement.assistant",
+    "agent_instance_id": "inst_HIGH_IMPACT_EXAMPLE",
+    "agent_product": "Example Procurement Agent",
+    "operator_id": "org.example",
+    "issuer_id": "issuer.example",
+    "runtime_environment": "prod/procurement/workflow"
+  },
+  "principal": {
+    "principal_type": "human_user",
+    "principal_id": "user_12345",
+    "principal_context": "procurement_request",
+    "principal_context_id": "req_20260426_high_impact_000001"
+  },
+  "delegation": {
+    "delegation_chain_id": "del_chain_high_impact_001",
+    "parent_action_id": "act_20260426_high_impact_000000",
+    "authority_scope": [
+      "vendor.quote.request",
+      "purchase_order.prepare"
+    ],
+    "constraints": {
+      "max_amount": "1000.00",
+      "currency": "USD",
+      "expires_at": "2026-04-26T01:00:00Z",
+      "max_count": 1,
+      "max_delegation_depth": 1,
+      "redelegation_allowed": false,
+      "allowed_resources": [
+        "vendor_xyz"
+      ],
+      "allowed_purposes": [
+        "office_supplies_procurement"
+      ]
+    },
+    "delegation_lineage": [
+      {
+        "lineage_node_id": "lineage_001",
+        "upstream_action_id": "act_20260426_high_impact_000000",
+        "upstream_agent_id": "agent.procurement.manager",
+        "downstream_agent_id": "agent.procurement.assistant",
+        "delegated_scope": [
+          "purchase_order.prepare"
+        ],
+        "delegated_constraints": [
+          "max_amount:1000.00",
+          "allowed_resource:vendor_xyz"
+        ],
+        "delegation_decision": "attenuated",
+        "decision_reference": "del_decision_001"
+      }
+    ]
+  },
+  "requested_action": {
+    "action_type": "purchase_order.create",
+    "resource": "vendor_xyz",
+    "purpose": "office_supplies_procurement",
+    "risk_level": "high",
+    "high_impact_category": "HIA-FIN",
+    "tool_name": "procurement_api",
+    "tool_operation": "create_purchase_order",
+    "argument_digest": "sha256:high-impact-example-argument-digest",
+    "external_effect_expected": true
+  },
+  "authorization": {
+    "decision": "requires_human_approval",
+    "policy_id": "policy.procurement.high_risk_actions.v1",
+    "reason": "purchase_order.create exceeds autonomous execution authority",
+    "decision_timestamp": "2026-04-26T00:01:00Z",
+    "trusted_inputs_used": [
+      "policy",
+      "authority_scope",
+      "principal_context",
+      "risk_classification"
+    ],
+    "untrusted_inputs_excluded": [
+      "retrieved_web_content",
+      "external_email_body"
+    ],
+    "revocation_state_checked": true,
+    "authorization_decision_artifact": {
+      "decision_id": "authz_20260426_high_impact_000001",
+      "decision": "requires_human_approval",
+      "bound_action_digest": "sha256:high-impact-example-bound-action-digest",
+      "principal_id": "user_12345",
+      "authority_scope": [
+        "vendor.quote.request",
+        "purchase_order.prepare"
+      ],
+      "resource": "vendor_xyz",
+      "expires_at": "2026-04-26T00:10:00Z",
+      "issuer": "policy_engine.procurement",
+      "signature_reference": "sig_20260426_high_impact_000001"
+    },
+    "intent_alignment": {
+      "principal_intent_reference": "req_20260426_high_impact_000001",
+      "policy_constraints_used": [
+        "approved_vendor_policy",
+        "procurement_limit_policy"
+      ],
+      "machine_enforceable_policy_reference": "policy.procurement.high_risk_actions.v1",
+      "human_readable_policy_summary": "Use approved vendors and stay within delegated procurement limits.",
+      "alignment_decision": "aligned",
+      "alignment_reason": "Requested vendor and amount matched structured authority constraints.",
+      "model_self_assessment_only": false
+    },
+    "state_checks": [
+      {
+        "state_source": "revocation_state",
+        "state_snapshot_id": "rev_state_20260425_000001",
+        "state_checked_at": "2026-04-26T00:00:55Z",
+        "state_result": "passed",
+        "conditional_policy_reference": "policy.revocation.check.v1"
+      },
+      {
+        "state_source": "vendor_status",
+        "state_snapshot_id": "vendor_state_vendor_xyz",
+        "state_checked_at": "2026-04-26T00:00:56Z",
+        "state_result": "passed",
+        "conditional_policy_reference": "policy.approved_vendor.v1"
+      }
+    ]
+  },
+  "approval": {
+    "approval_required": true,
+    "approval_id": "approval_high_impact_000001",
+    "approver_id": "manager_456",
+    "approval_decision": "approved",
+    "approval_timestamp": "2026-04-26T00:05:00Z",
+    "approval_context_presented": [
+      "agent_id",
+      "principal_id",
+      "requested_action",
+      "resource",
+      "purpose",
+      "risk_level",
+      "authority_scope",
+      "expected_external_effect"
+    ],
+    "source_type": "workflow",
+    "source_system": "change-approval-workflow",
+    "workflow_record_id": "chg-approval-20260430-0001",
+    "trusted_source": true,
+    "context_presented_ref": "approval-context://chg-approval-20260430-0001/view",
+    "approver_view_ref": "approval-ui://chg-approval-20260430-0001/approver-view",
+    "canonical_action_id": "canonical-action-approval-binding-001",
+    "action_digest": "sha256:7e4f6b2b0c8a9d3f1a2b4c6d8e0f1234567890abcdef1234567890abcdef1234",
+    "approved_scope": {
+      "operation_class": "execute",
+      "target_resource": "production-customer-notification-workflow",
+      "max_impact": "external_customer_notification",
+      "expires_at": "2026-04-30T02:00:00Z"
+    },
+    "approved_operation_class": "execute",
+    "enforcement_check_id": "approval-enforcement-check-20260430-0001",
+    "enforcement_result": "allow",
+    "checked_at_execution_boundary": true,
+    "model_summary_trusted_as_evidence": false
+  },
+  "context": {
+    "input_sources": [
+      {
+        "source_type": "user_instruction",
+        "source_id": "req_20260426_high_impact_000001",
+        "trust_level": "trusted",
+        "provenance": "internal_workflow",
+        "content_digest": "sha256:example-user-instruction-digest",
+        "materially_influenced_action": true
+      },
+      {
+        "source_type": "retrieved_web_content",
+        "source_id": "web_001",
+        "trust_level": "untrusted",
+        "provenance": "external_vendor_page",
+        "content_digest": "sha256:example-retrieved-content-digest",
+        "materially_influenced_action": false
+      }
+    ],
+    "untrusted_content_influenced_action": false,
+    "retrieved_or_remembered_content_material": false,
+    "correlation_id": "corr_high_impact_000001",
+    "trace_id": "trace_high_impact_000001",
+    "input_influence_assessment": {
+      "untrusted_content_influenced_action": false,
+      "determined_by": "runtime_input_tracker",
+      "method": "source_tracking",
+      "confidence": "medium",
+      "limitations": "Semantic influence cannot be fully excluded; assessment is based on recorded source use, trusted authorization inputs, and runtime tracking."
+    }
+  },
+  "result": {
+    "status": "allowed_after_approval",
+    "tool_invoked": "procurement_api.create_purchase_order",
+    "tool_result_reference": "po_000123",
+    "external_effect": true,
+    "result_digest": "sha256:high-impact-example-result-digest"
+  },
+  "evidence": {
+    "evidence_id": "ev_20260426_high_impact_000001",
+    "evidence_hash": "sha256:high-impact-example-evidence-hash",
+    "retention_class": "high_impact_action",
+    "tamper_evidence": "signed_log_entry",
+    "evidence_location": "evidence-store://aaef/events/act_20260426_high_impact_000001",
+    "privacy_notes": "Raw tool arguments are not stored; argument_digest is retained.",
+    "evidence_trust_limitation": [
+      "The approval workflow record is treated as the trusted approval evidence source.",
+      "Model-generated approval summaries are retained as context only and are not treated as trusted approval evidence."
+    ]
+  },
+  "response": {
+    "revocation_triggered": false,
+    "isolation_triggered": false,
+    "incident_reference": "none"
+  },
+  "non_execution": {
+    "non_execution_decision": "not_applicable",
+    "reason": "Action proceeded after required approval."
+  },
+  "reauthorization": {
+    "reauthorization_requested": false,
+    "reauthorization_decision": "not_requested",
+    "retry_count": 0
+  },
+  "override": {
+    "override_triggered": false
+  },
+  "extensions": {
+    "evidence_profile": "high-impact",
+    "profile_notes": "Example high-impact evidence event demonstrating action-bound authorization, human approval, input influence assessment, and tamper-evident evidence references.",
+    "policy_version": "policy.procurement.high_risk_actions.v1",
+    "dispatch_attestation_reference": "dispatch_attest_20260426_high_impact_000001",
+    "canonicalization_method": "implementation-defined",
+    "digest_algorithm": "sha-256",
+    "data_classification": "internal",
+    "redaction_applied": true,
+    "example_purpose": "Demonstrates trusted approval evidence source, approval-to-action binding, and execution-bound approval enforcement.",
+    "example_status": "non_normative_example",
+    "approval_authority_note": "Approval was based on action-bound workflow context. Model-generated summaries were not treated as approval authority."
+  }
+}

--- a/tools/validate_evidence_schema.py
+++ b/tools/validate_evidence_schema.py
@@ -32,6 +32,7 @@ VALID_EXAMPLES = [
     REPO_ROOT / "examples" / "agentic-action-evidence-event.high-impact.json",
     REPO_ROOT / "examples" / "agentic-action-evidence-event.audit-grade.json",
     REPO_ROOT / "examples" / "agentic-action-evidence-event.integrity-e5.json",
+    REPO_ROOT / "examples" / "agentic-action-evidence-event.approval-binding.json",
 ]
 
 INVALID_EXAMPLES = [


### PR DESCRIPTION
## Summary

This PR adds an approval-to-execution binding evidence example.

Changes include:

- Add `examples/agentic-action-evidence-event.approval-binding.json`
- Demonstrate optional approval evidence source fields
- Demonstrate optional approval-to-action binding fields
- Demonstrate optional approved scope and approved operation class fields
- Demonstrate optional execution-bound approval enforcement fields
- Demonstrate explicit treatment of model-generated approval summaries as non-trusted approval evidence
- Add the new example to `tools/validate_evidence_schema.py`
- Update the evidence example design proposal and implementation readiness review
- Add an Unreleased changelog entry

## Validation

Validated locally:

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is an example addition.

It changes:

- `examples/agentic-action-evidence-event.approval-binding.json`
- `tools/validate_evidence_schema.py`

It does not:

- update the Evidence Event Schema
- add required schema fields
- update testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, or #167

## Related

Related follow-up issues:

- #167
- #165
- #161
- #163

Related PRs:

- #209
- #210

Related planning documents:

- `docs/en/status/v050x-evidence-example-design-proposal.md`
- `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md`
- `docs/en/status/v050x-evidence-schema-field-proposal.md`

Milestone: v0.5.x Follow-up

Labels: examples, evidence, v0.5.x, discussion-needed