### PR TITLE
Update v0.5.x status after evidence schema examples implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated v0.5.x status documents after the first evidence schema and example implementation wave.
+
 ### Added
 
 - Added an approval-binding evidence example using optional approval source, approval binding, and enforcement fields.

--- a/docs/en/status/v050x-evidence-schema-example-implementation-readiness.md
+++ b/docs/en/status/v050x-evidence-schema-example-implementation-readiness.md
@@ -319,3 +319,25 @@ The second example PR adds the approval-to-execution binding evidence example:
 This follows the planned schema-first, example-follow-up approach.
 
 The example demonstrates trusted approval source, approval binding, approval scope, and execution-bound approval enforcement using optional schema fields.
+
+## Implementation Completion after #209, #210, and #211
+
+The initial implementation sequence described in this readiness review has been completed.
+
+Completed implementation sequence:
+
+1. #209 added optional schema support for evidence integrity and approval evidence fields.
+2. #210 added the tamper-evident / integrity-verifiable evidence example.
+3. #211 added the approval-to-execution binding evidence example.
+
+This completed the initial schema-first, example-follow-up path.
+
+The following items remain outside the first implementation wave:
+
+- evidence integrity negative tests;
+- evidence replay, reordering, truncation, deletion, and selective omission tests;
+- incident-response evidence preservation guidance;
+- approval semantics beyond the positive approval-binding example;
+- principal context freshness schema fields;
+- delegation lineage schema fields;
+- cleanup or consolidation of temporary status documents.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -211,3 +211,28 @@ Current checkpoint:
 For the consolidated checkpoint, see `docs/en/status/v050x-incorporation-review-checkpoint.md`.
 
 The next phase should split remaining work into smaller tracks for evidence schema and examples, negative tests, delegation semantics, approval semantics, and cleanup/publication readiness.
+
+## Update after #209, #210, and #211
+
+PRs #209, #210, and #211 completed the first implementation wave for the v0.5.x evidence schema and examples track.
+
+Implemented work:
+
+- #209 added optional Evidence Event Schema fields for evidence integrity, evidence trust limitations, approval evidence source, approval-to-action binding, and execution-bound approval enforcement references.
+- #210 added `examples/agentic-action-evidence-event.integrity-e5.json`.
+- #211 added `examples/agentic-action-evidence-event.approval-binding.json`.
+
+This completes the first schema-first, example-follow-up implementation sequence described in:
+
+- `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md`
+- `docs/en/status/v050x-evidence-schema-field-proposal.md`
+- `docs/en/status/v050x-evidence-example-design-proposal.md`
+
+Current issue status:
+
+- #165 remains open because evidence integrity negative tests, replay/reordering/selective omission tests, incident-response evidence preservation guidance, and any evidence-depth/profile decisions remain pending.
+- #167 remains open because approval semantics, draft-vs-execute approval, post-approval modification, approval fatigue, and related HUM/AUZ/EVD testing decisions remain pending.
+- #161 remains open because principal context freshness/degradation schema or profile treatment was explicitly deferred.
+- #163 remains open because delegation lineage and receiving-side validation schema treatment was explicitly deferred.
+
+No active testing procedure CSV changes were made in #209, #210, or #211.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -476,3 +476,36 @@ The next incorporation phase should focus on smaller follow-up decisions rather 
 - delegation semantics;
 - approval semantics;
 - status document cleanup and publication readiness.
+
+## Incorporation Update after #209, #210, and #211
+
+PRs #209, #210, and #211 completed the first implementation wave for the evidence schema and examples track.
+
+Incorporation decisions implemented:
+
+| PR | Decision | Result |
+| --- | --- | --- |
+| #209 | Add narrow optional schema support before examples | Optional fields added under evidence and approval schema definitions |
+| #210 | Add first integrity-focused example | `agentic-action-evidence-event.integrity-e5.json` added and validated |
+| #211 | Add approval-to-execution binding example | `agentic-action-evidence-event.approval-binding.json` added and validated |
+
+The implementation followed the selected path:
+
+- schema-first;
+- example-follow-up;
+- optional fields only;
+- no active testing procedure CSV changes;
+- no new control IDs;
+- no principal context or delegation lineage schema fields in the first implementation wave.
+
+This confirms that the first T1 implementation wave is complete.
+
+Remaining incorporation decisions include:
+
+- whether evidence integrity negative tests should become active testing refinements, example artifacts, or separate guidance;
+- whether evidence depth such as E5 should become profile guidance or remain example terminology;
+- whether approval semantics require further HUM/AUZ/EVD testing procedure refinement;
+- whether trusted approval evidence source expectations require additional `AAEF-EVD-03` refinement;
+- whether principal context freshness/degradation requires schema fields later;
+- whether delegation lineage or receiving-side validation requires schema fields later;
+- whether temporary planning documents should be consolidated after the next follow-up cycle.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after the first evidence schema and example implementation wave.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Update `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md`
- Record that #209 added optional Evidence Event Schema fields for evidence integrity and approval evidence
- Record that #210 added the integrity-focused evidence example
- Record that #211 added the approval-to-execution binding evidence example
- Record that the first T1 schema-first, example-follow-up implementation wave is complete
- Clarify remaining work for #165, #167, #161, and #163
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation update.

It does not:

- update the Evidence Event Schema
- add evidence examples
- update testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, or #167

## Related

Related PRs:

- #209
- #210
- #211

Related follow-up issues:

- #161
- #163
- #165
- #167

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x