### PR TITLE
Update v0.5.x status after evidence integrity testing review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated v0.5.x status after reviewing evidence integrity testing procedure coverage.
+
 ### Added
 
 - Added a temporary v0.5.x evidence integrity negative tests CSV refinement proposal.

--- a/docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md
+++ b/docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md
@@ -224,3 +224,17 @@ This proposal does not:
 - close #161, #163, #165, or #167.
 
 It records the incorporation decision before any active CSV modification.
+
+## Active Row Review Outcome
+
+After this proposal, the active `AAEF-EVD-04` row was reviewed against the proposed evidence integrity negative testing concepts.
+
+Outcome:
+
+- no immediate active CSV refinement is required;
+- the existing row already covers the core negative test concepts;
+- no testing procedure rows were added;
+- no candidate IDs were added to the active CSV;
+- no schema, examples, controls, profiles, worksheet, or mapping changes were needed.
+
+This changes the next step from active CSV modification to status tracking and remaining-work planning for #165.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -236,3 +236,18 @@ Current issue status:
 - #163 remains open because delegation lineage and receiving-side validation schema treatment was explicitly deferred.
 
 No active testing procedure CSV changes were made in #209, #210, or #211.
+
+## Update after evidence integrity testing row review
+
+After #215, the active `AAEF-EVD-04` testing procedure row was reviewed for evidence integrity negative testing coverage.
+
+Review result:
+
+- No active CSV refinement is required at this time.
+- The existing `AAEF-EVD-04` row already covers alteration, deletion, replay, reordering, truncation, selective omission, integrity verification, retention/deletion/redaction records, and evidence trust limitations.
+- The attempted active CSV refinement branch produced no repository changes and was deleted without a PR.
+
+Current issue status:
+
+- #165 remains open because incident-response evidence preservation guidance, evidence depth/profile decisions, possible evidence integrity negative examples or validator fixtures, and later evidence sufficiency / limitation review remain pending.
+- `AAEF-EVD-04` does not need immediate active CSV modification based on the current review.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -509,3 +509,37 @@ Remaining incorporation decisions include:
 - whether principal context freshness/degradation requires schema fields later;
 - whether delegation lineage or receiving-side validation requires schema fields later;
 - whether temporary planning documents should be consolidated after the next follow-up cycle.
+
+## Incorporation Decision after Evidence Integrity Testing Row Review
+
+After #215, `AAEF-EVD-04` was reviewed against the evidence integrity negative test candidates.
+
+Decision:
+
+| Area | Decision |
+| --- | --- |
+| Active CSV change | Not required at this time |
+| Target row | `AAEF-EVD-04` |
+| Rationale | Existing testing objective, method, evidence, pass criteria, partial criteria, and fail conditions already cover the main negative test concepts |
+| Candidate IDs in active CSV | Not added |
+| New control IDs | Not added |
+| Schema or example changes | Not required |
+
+Observed existing coverage includes:
+
+- undetected alteration;
+- deletion;
+- replay;
+- reordering;
+- truncation;
+- selective omission;
+- integrity verification;
+- evidence trust limitations;
+- retention, deletion, and redaction documentation.
+
+Remaining decisions for #165:
+
+- whether incident-response evidence preservation guidance is needed;
+- whether evidence depth such as E5 should become profile guidance or remain example terminology;
+- whether negative examples or validator fixtures would improve reviewability;
+- whether `AAEF-EVD-01` should later receive evidence sufficiency / limitation refinement.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after reviewing the active `AAEF-EVD-04` testing procedure row against the evidence integrity negative test candidates.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Update `docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md`
- Record that no active CSV refinement is required at this time
- Record that existing `AAEF-EVD-04` coverage already includes alteration, deletion, replay, reordering, truncation, selective omission, integrity verification, and evidence trust limitations
- Record that the attempted active CSV refinement branch produced no repository changes and was deleted
- Clarify remaining #165 work
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, or #167

## Related

Related follow-up issue:

- #165

Related recent PRs:

- #213
- #214
- #215

Related active row:

- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, testing, evidence, v0.5.x