### PR TITLE
Update v0.5.x status after evidence depth E5 decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated v0.5.x status after the evidence depth and E5 profile decision proposal.
+
 ### Added
 
 - Added a temporary v0.5.x evidence depth and E5 profile decision proposal.

--- a/docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md
+++ b/docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md
@@ -265,3 +265,18 @@ This proposal does not:
 - close #161, #163, #165, or #167.
 
 It records the evidence depth / E5 decision proposal before any active incorporation decision.
+
+## Status after Initial Decision
+
+This proposal records the current v0.5.x decision for evidence depth and E5 terminology.
+
+Current incorporation status:
+
+- E5 is retained as non-normative evidence depth terminology.
+- No E5 certification tier is created.
+- No E5 formal profile is created in this cycle.
+- No evidence depth schema field is added.
+- No active CSV requirement is added.
+- No evidence example or validator fixture change is required by this decision.
+
+The remaining question is whether evidence depth vocabulary should later be consolidated into stable reviewer guidance, assessment quick-start material, or retained as temporary planning material.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -291,3 +291,24 @@ Current #165 status:
 The evidence depth and E5 profile decision proposal is recorded in `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md`.
 
 The proposal recommends treating E5 as non-normative evidence depth terminology for examples, review, and future guidance, not as a certification level, required schema value, or active testing procedure requirement.
+
+## Update after #220
+
+PR #220 added the v0.5.x evidence depth and E5 profile decision proposal.
+
+Implemented work:
+
+- #220 added `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md`.
+
+Current result:
+
+- E5 is treated as non-normative evidence depth terminology for examples, review, and future guidance.
+- E5 is not treated as a certification tier, formal profile, required schema value, active CSV requirement, or scoring scale in the current v0.5.x cycle.
+- No active testing procedure CSV change is required from #220.
+- No Evidence Event Schema change is required from #220.
+- No evidence example or validator fixture change is required from #220.
+
+Current #165 status:
+
+- Evidence integrity schema support, integrity-focused example, evidence integrity negative test planning, incident-response preservation guidance, incident-response preservation candidate coverage, and E5/evidence depth decision work are now substantially addressed for the current v0.5.x follow-up cycle.
+- #165 remains open because possible negative examples or validator fixtures, possible `AAEF-EVD-01` evidence sufficiency / limitation review, and temporary-document consolidation remain pending.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -621,3 +621,32 @@ Decision status:
 | Future guidance | Candidate for later work |
 
 The proposal records that evidence depth vocabulary may be useful for review and guidance, but should not become a formal certification or required schema/profile mechanism in the current v0.5.x cycle.
+
+## Incorporation Decision after Evidence Depth and E5 Decision
+
+After #220, the evidence depth / E5 treatment for #165 was reviewed.
+
+Decision:
+
+| Area | Decision |
+| --- | --- |
+| E5 formal profile | Deferred |
+| Certification scale | Not created |
+| Required schema field | Not added |
+| Active CSV requirement | Not added |
+| Example terminology | Allowed with non-normative framing |
+| Future guidance | Candidate for later work |
+| Primary active row | `AAEF-EVD-04` |
+
+Rationale:
+
+- E5 is useful as review vocabulary for stronger, dispute-grade, integrity-verifiable evidence.
+- Formalizing E5 too early could create false assurance, certification confusion, mechanism lock-in, schema overreach, and audit gaming risk.
+- The current v0.5.x cycle should preserve E5 as explanatory terminology rather than a compliance tier or required field.
+
+Remaining decisions for #165:
+
+- whether negative evidence examples or validator fixtures would improve reviewability;
+- whether `AAEF-EVD-01` should later receive evidence sufficiency / limitation refinement;
+- whether evidence depth guidance should be created later from the temporary proposal;
+- whether temporary planning documents should be consolidated after the current follow-up cycle.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after adding the evidence depth and E5 profile decision proposal.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Update `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md`
- Record that #220 added the evidence depth and E5 profile decision proposal
- Record that E5 is treated as non-normative evidence depth terminology
- Record that E5 is not a certification tier, formal profile, required schema value, active CSV requirement, or scoring scale in the current v0.5.x cycle
- Clarify remaining #165 work
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- create an evidence depth certification scale
- add a required evidence depth field
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, or #167

## Related

Related follow-up issue:

- #165

Related recent PR:

- #220

Related active row:

- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x