### PR TITLE
Update v0.5.x status after negative evidence fixtures decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated v0.5.x status after the negative evidence examples and validator fixtures decision proposal.
+
 ### Added
 
 - Added a temporary v0.5.x negative evidence examples and validator fixtures decision proposal.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -318,3 +318,24 @@ Current #165 status:
 The negative evidence examples and validator fixtures decision proposal is recorded in `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md`.
 
 The proposal recommends not adding schema-invalid validator fixtures or negative evidence examples immediately. It distinguishes structural schema validity from semantic evidence sufficiency and treats schema-valid negative evidence examples as possible future reviewer-facing guidance.
+
+## Update after #222
+
+PR #222 added the v0.5.x negative evidence examples and validator fixtures decision proposal.
+
+Implemented work:
+
+- #222 added `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md`.
+
+Current result:
+
+- Schema-invalid validator fixtures are not added in the current v0.5.x cycle.
+- Schema-valid negative evidence examples are deferred.
+- `tools/validate_evidence_schema.py` remains focused on structural schema validation.
+- Evidence integrity failure is treated primarily as a semantic or assurance issue, not a JSON Schema validity issue.
+- Reviewer-facing negative examples remain candidate future work.
+
+Current #165 status:
+
+- Evidence integrity schema support, integrity-focused example, evidence integrity negative test planning, incident-response preservation guidance, incident-response preservation candidate coverage, E5/evidence depth decision work, and negative example / validator fixture decision work are now substantially addressed for the current v0.5.x follow-up cycle.
+- #165 remains open because possible `AAEF-EVD-01` evidence sufficiency / limitation review and temporary-document consolidation remain pending.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -667,3 +667,32 @@ Decision status:
 | Future reviewer-facing examples | Candidate future work |
 
 The proposal records that most evidence integrity failure states are semantic or assurance failures rather than JSON Schema failures.
+
+## Incorporation Decision after Negative Evidence Examples and Validator Fixtures Decision
+
+After #222, the negative evidence examples and validator fixtures question for #165 was reviewed.
+
+Decision:
+
+| Area | Decision |
+| --- | --- |
+| Schema-invalid fixtures | Not added in this cycle |
+| Schema-valid negative examples | Deferred |
+| Validator behavior | Unchanged |
+| Evidence Event Schema | Unchanged |
+| Active CSV | Unchanged |
+| Reviewer-facing negative examples | Candidate future work |
+| Primary active row | `AAEF-EVD-04` |
+
+Rationale:
+
+- Most evidence integrity failure states are semantic or assurance failures rather than JSON Schema failures.
+- A failed, partial, unavailable, or limitation-bearing evidence state can be valid to record.
+- Schema validity should not be confused with evidence sufficiency, evidence completeness, or tamper-evidence.
+- The validator should continue to answer whether an evidence event is structurally valid, not whether the evidence is sufficient or trustworthy.
+
+Remaining decisions for #165:
+
+- whether `AAEF-EVD-01` should later receive evidence sufficiency / limitation refinement;
+- whether evidence depth guidance should be created later from the temporary proposal;
+- whether temporary planning documents should be consolidated after the current follow-up cycle.

--- a/docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md
+++ b/docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md
@@ -230,3 +230,18 @@ This proposal does not:
 - close #161, #163, #165, or #167.
 
 It records the negative evidence examples and validator fixtures decision proposal before any active incorporation decision.
+
+## Status after Initial Decision
+
+This proposal records the current v0.5.x decision for negative evidence examples and validator fixtures.
+
+Current incorporation status:
+
+- schema-invalid validator fixtures are not added in this cycle;
+- schema-valid negative evidence examples are deferred;
+- validator behavior remains unchanged;
+- the Evidence Event Schema remains unchanged;
+- active testing procedures remain unchanged;
+- reviewer-facing negative examples remain candidate future work.
+
+The remaining question is whether evidence sufficiency and evidence limitation language should later be reviewed under `AAEF-EVD-01`.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after adding the negative evidence examples and validator fixtures decision proposal.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Update `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md`
- Record that #222 added the negative evidence examples and validator fixtures decision proposal
- Record that schema-invalid validator fixtures are not added in the current v0.5.x cycle
- Record that schema-valid negative evidence examples are deferred
- Record that `tools/validate_evidence_schema.py` remains focused on structural schema validation
- Record that evidence integrity failure is treated primarily as a semantic or assurance issue, not a JSON Schema validity issue
- Clarify remaining #165 work
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation update.

It does not:

- add negative examples
- add validator fixtures
- update `tools/validate_evidence_schema.py`
- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- create a certification scale
- close #161, #163, #165, or #167

## Related

Related follow-up issue:

- #165

Related recent PR:

- #222

Related active row:

- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x