### PR TITLE
Update v0.5.x status after EVD-01 evidence sufficiency review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated v0.5.x status after reviewing `AAEF-EVD-01` evidence sufficiency coverage.
+
 ### Added
 
 - Added a temporary v0.5.x `AAEF-EVD-01` evidence sufficiency and limitation review proposal.

--- a/docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md
+++ b/docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md
@@ -265,3 +265,30 @@ This proposal does not:
 - close #161, #163, #165, or #167.
 
 It records the `AAEF-EVD-01` evidence sufficiency and limitation review proposal before any active incorporation decision.
+
+## Active Row Review Outcome
+
+The active `AAEF-EVD-01` testing procedure row was reviewed after this proposal.
+
+Outcome:
+
+- no immediate active CSV refinement is required;
+- the existing row already covers the reviewed sufficiency and limitation concepts;
+- no testing procedure rows were added;
+- no candidate IDs were added to the active CSV;
+- no schema, examples, controls, profiles, worksheet, or mapping changes were needed.
+
+Observed coverage includes:
+
+- evidence sufficient to reconstruct sampled high-impact actions;
+- authority basis;
+- requested action;
+- resource;
+- decision path;
+- dispatch or execution result;
+- timestamp;
+- correlation identifiers;
+- partial reconstruction gaps;
+- missing, self-reported-only, contradictory, or insufficient evidence as fail conditions.
+
+This changes the next step from active CSV modification to status tracking and temporary-document consolidation planning for #165.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -345,3 +345,18 @@ Current #165 status:
 The `AAEF-EVD-01` evidence sufficiency and limitation review proposal is recorded in `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md`.
 
 The proposal opens review of whether `AAEF-EVD-01` needs narrow refinement to distinguish evidence sufficiency from evidence integrity, schema validity, and model-generated or self-reported evidence.
+
+## Update after AAEF-EVD-01 evidence sufficiency review
+
+After #224, the active `AAEF-EVD-01` testing procedure row was reviewed for evidence sufficiency and limitation coverage.
+
+Review result:
+
+- No active CSV refinement is required at this time.
+- The existing `AAEF-EVD-01` row already covers evidence completeness, high-impact action sampling, authorization, dispatch, backend and evidence records, reconstruction sufficiency, partial reconstruction gaps, and self-reported-only evidence failure.
+- The coverage scan found the reviewed sufficiency criteria likely covered, including action-bound evidence, risk-proportionate evidence, self-report limitation, missing or partial evidence limitation, authorization/execution traceability, and insufficient-evidence fail handling.
+
+Current #165 status:
+
+- Evidence integrity schema support, integrity-focused example, evidence integrity negative test planning, incident-response preservation guidance, incident-response preservation candidate coverage, E5/evidence depth decision work, negative example / validator fixture decision work, and `AAEF-EVD-01` sufficiency review are now substantially addressed for the current v0.5.x follow-up cycle.
+- #165 remains open only for temporary-document consolidation and any later decision on whether stable guidance should be extracted from the temporary v0.5.x materials.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -713,3 +713,32 @@ Decision status:
 | Validator change | Not required in this proposal |
 
 The proposal records that evidence sufficiency is distinct from evidence integrity and schema validity.
+
+## Incorporation Decision after AAEF-EVD-01 Evidence Sufficiency Review
+
+After #224, `AAEF-EVD-01` was reviewed for evidence sufficiency and limitation coverage.
+
+Decision:
+
+| Area | Decision |
+| --- | --- |
+| Active CSV change | Not required at this time |
+| Target row | `AAEF-EVD-01` |
+| Related row | `AAEF-EVD-04` |
+| Schema change | Not required |
+| Example change | Not required |
+| Validator change | Not required |
+| Guidance extraction | Candidate future work |
+
+Rationale:
+
+- `AAEF-EVD-01` already requires evidence sufficient to reconstruct what happened for sampled high-impact actions.
+- The active row already references initiated-by, authority basis, requested action, resource, decision path, dispatch or execution result, timestamp, and correlation identifiers.
+- Partial criteria already cover reconstruction gaps in authority, dispatch, result, timing, or correlation identifiers.
+- Fail conditions already cover missing, self-reported-only, contradictory, or insufficient evidence.
+- The row is sufficient for the current v0.5.x follow-up cycle without active CSV modification.
+
+Remaining decisions for #165:
+
+- whether temporary planning documents should be consolidated after the current follow-up cycle;
+- whether stable evidence sufficiency, evidence depth, or incident-response preservation guidance should be extracted later.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after reviewing the active `AAEF-EVD-01` testing procedure row for evidence sufficiency and limitation coverage.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Update `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md`
- Record that no active CSV refinement is required at this time
- Record that existing `AAEF-EVD-01` coverage already includes evidence completeness, high-impact action sampling, authorization, dispatch, backend and evidence records, reconstruction sufficiency, partial reconstruction gaps, and self-reported-only evidence failure
- Record that the reviewed sufficiency criteria are likely covered
- Clarify remaining #165 work
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- update `tools/validate_evidence_schema.py`
- create an evidence depth certification scale
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, or #167

## Related

Related follow-up issue:

- #165

Related recent PR:

- #224

Primary row reviewed:

- `AAEF-EVD-01`

Related active row:

- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x