### PR TITLE
Add v0.5.x issue 165 evidence integrity consolidation checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added a temporary v0.5.x issue #165 evidence integrity consolidation checkpoint.
+
 ### Changed
 
 - Updated v0.5.x status after reviewing `AAEF-EVD-01` evidence sufficiency coverage.

--- a/README.md
+++ b/README.md
@@ -304,7 +304,8 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │           ├── v050x-incident-response-evidence-preservation-candidate-appendix.md
 │           ├── v050x-evidence-depth-e5-profile-decision-proposal.md
 │           ├── v050x-negative-evidence-examples-fixtures-decision-proposal.md
-│           └── v050x-evd01-evidence-sufficiency-limitation-review-proposal.md
+│           ├── v050x-evd01-evidence-sufficiency-limitation-review-proposal.md
+│           └── v050x-issue-165-evidence-integrity-consolidation-checkpoint.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -84,6 +84,8 @@ For the v0.5.x negative evidence examples and validator fixtures decision propos
 
 For the v0.5.x `AAEF-EVD-01` evidence sufficiency and limitation review proposal, see `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md`.
 
+For the v0.5.x issue #165 evidence integrity consolidation checkpoint, see `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`.
+
 ## Research Motivation
 
 AAEF focuses on a specific problem in agentic AI assurance:

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -162,6 +162,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` | v0.5.x evidence depth and E5 profile decision proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md` | v0.5.x negative evidence examples and validator fixtures decision proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` | v0.5.x AAEF-EVD-01 evidence sufficiency and limitation review proposal | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md` | v0.5.x issue #165 evidence integrity consolidation checkpoint | Temporary status / coordination material |
 
 ## Physical Organization Policy
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -72,3 +72,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md`
 - `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md`
 - `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md`
+- `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -360,3 +360,9 @@ Current #165 status:
 
 - Evidence integrity schema support, integrity-focused example, evidence integrity negative test planning, incident-response preservation guidance, incident-response preservation candidate coverage, E5/evidence depth decision work, negative example / validator fixture decision work, and `AAEF-EVD-01` sufficiency review are now substantially addressed for the current v0.5.x follow-up cycle.
 - #165 remains open only for temporary-document consolidation and any later decision on whether stable guidance should be extracted from the temporary v0.5.x materials.
+
+## Issue #165 Evidence Integrity Consolidation Checkpoint
+
+The #165 evidence integrity consolidation checkpoint is recorded in `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`.
+
+The checkpoint records that the major #165 workstreams are substantially addressed for the current v0.5.x follow-up cycle and that #165 appears close-ready if stable guidance extraction is tracked separately.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -742,3 +742,20 @@ Remaining decisions for #165:
 
 - whether temporary planning documents should be consolidated after the current follow-up cycle;
 - whether stable evidence sufficiency, evidence depth, or incident-response preservation guidance should be extracted later.
+
+## Issue #165 Evidence Integrity Consolidation Checkpoint
+
+A temporary consolidation checkpoint was added in `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`.
+
+Decision status:
+
+| Area | Decision |
+| --- | --- |
+| Active CSV change | Not required |
+| Evidence Event Schema change | Not required |
+| Example change | Not required |
+| Validator change | Not required |
+| Stable guidance extraction | Candidate future work |
+| Issue disposition | Close-ready if future guidance extraction is tracked separately |
+
+The checkpoint consolidates the #165 evidence integrity and tamper-evident evidence follow-up decisions for the current v0.5.x cycle.

--- a/docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md
+++ b/docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md
@@ -1,0 +1,205 @@
+# v0.5.x Issue #165 Evidence Integrity Consolidation Checkpoint
+
+**Status:** Temporary, non-normative consolidation checkpoint
+
+## Purpose
+
+This document consolidates the v0.5.x follow-up work related to #165: evidence integrity and tamper-evident evidence.
+
+It records:
+
+- completed work;
+- decisions made;
+- areas intentionally deferred;
+- whether active CSV, schema, example, or validator changes remain necessary;
+- whether #165 is close-ready after the current follow-up sequence.
+
+This document does not update active testing procedures.
+
+It does not update the Evidence Event Schema.
+
+It does not add evidence examples.
+
+It does not add validator fixtures.
+
+It does not close #165 by itself.
+
+## Summary Result
+
+The main #165 workstreams are substantially addressed for the current v0.5.x follow-up cycle.
+
+Current result:
+
+- evidence integrity schema support was added;
+- positive integrity and approval-binding examples were added;
+- evidence integrity negative testing was planned and reviewed;
+- `AAEF-EVD-04` was reviewed and did not require active CSV modification;
+- incident-response evidence preservation guidance was added;
+- incident-response preservation candidate scenarios were added;
+- E5 / evidence depth was defined as non-normative review vocabulary, not a certification scale;
+- negative evidence examples and validator fixtures were reviewed and deferred;
+- `AAEF-EVD-01` evidence sufficiency coverage was reviewed and did not require active CSV modification.
+
+Recommended issue disposition:
+
+- #165 is close-ready after this consolidation checkpoint if maintainers accept that stable guidance extraction can be tracked separately.
+- If maintainers want to keep #165 open, the only remaining scope should be temporary-document consolidation or extraction into stable guidance.
+
+## Completed Workstreams
+
+| Workstream | Status | Key result |
+| --- | --- | --- |
+| Evidence integrity schema support | Completed | Optional evidence integrity and approval evidence fields added. |
+| Positive evidence examples | Completed | Integrity-focused and approval-binding examples added. |
+| Evidence integrity negative tests | Completed for current cycle | Candidate tests documented; active `AAEF-EVD-04` change not required. |
+| Active `AAEF-EVD-04` review | Completed | Existing row already covers core negative evidence integrity concepts. |
+| Incident-response evidence preservation | Completed for current cycle | Guidance proposal and candidate appendix added. |
+| Evidence depth / E5 decision | Completed for current cycle | E5 retained as non-normative review vocabulary. |
+| Negative examples / validator fixtures | Completed for current cycle | Deferred; validator remains structural. |
+| Active `AAEF-EVD-01` sufficiency review | Completed | Existing row already covers sufficiency and limitation concerns. |
+| Temporary-document consolidation | Pending / future | May be handled after the v0.5.x follow-up cycle. |
+
+## Related PR Sequence
+
+| PR | Result |
+| --- | --- |
+| #201 | Added v0.5.x evidence integrity CSV refinement proposal. |
+| #202 | Updated v0.5.x status after evidence integrity review. |
+| #209 | Added optional evidence integrity and approval schema fields. |
+| #210 | Added integrity E5 evidence example. |
+| #211 | Added approval binding evidence example. |
+| #212 | Updated status after evidence schema examples implementation. |
+| #213 | Added evidence integrity negative tests track proposal. |
+| #214 | Added evidence integrity negative tests candidate appendix. |
+| #215 | Added evidence integrity negative tests CSV refinement proposal. |
+| #216 | Recorded that active `AAEF-EVD-04` CSV refinement was not required. |
+| #217 | Added incident-response evidence preservation guidance proposal. |
+| #218 | Added incident-response evidence preservation candidate appendix. |
+| #219 | Updated status after incident-response preservation work. |
+| #220 | Added evidence depth and E5 profile decision proposal. |
+| #221 | Updated status after E5 / evidence depth decision. |
+| #222 | Added negative evidence examples and validator fixtures decision proposal. |
+| #223 | Updated status after negative evidence fixtures decision. |
+| #224 | Added `AAEF-EVD-01` evidence sufficiency and limitation review proposal. |
+| #225 | Recorded that active `AAEF-EVD-01` CSV refinement was not required. |
+
+## Current Active CSV Decision
+
+No active testing procedure CSV change is required for #165 at this time.
+
+Reviewed rows:
+
+| Row | Review outcome |
+| --- | --- |
+| `AAEF-EVD-04` | Existing row already covers alteration, deletion, replay, reordering, truncation, selective omission, integrity verification, and evidence trust limitations. |
+| `AAEF-EVD-01` | Existing row already covers evidence completeness, high-impact sampling, authorization, dispatch, backend and evidence records, reconstruction sufficiency, partial reconstruction gaps, and self-reported-only evidence failure. |
+
+No new testing rows are needed.
+
+No candidate IDs should be added to active CSV.
+
+## Current Schema Decision
+
+No further Evidence Event Schema change is required for #165 at this time.
+
+Current decision:
+
+- optional evidence integrity fields are sufficient for the current cycle;
+- evidence depth / E5 should not become a required schema field;
+- negative evidence states should not be forced into schema-invalid fixtures;
+- semantic evidence sufficiency should remain an assessment and review concern, not a schema-validity claim.
+
+## Current Example Decision
+
+No further evidence example change is required for #165 at this time.
+
+Current decision:
+
+- integrity-focused example added;
+- approval-binding example added;
+- schema-valid negative evidence examples are deferred;
+- reviewer-facing negative examples remain candidate future work;
+- examples should not create an implicit certification or evidence-depth scale.
+
+## Current Validator Decision
+
+No validator change is required for #165 at this time.
+
+Current decision:
+
+- `tools/validate_evidence_schema.py` remains focused on structural schema validation;
+- validator fixtures should not imply evidence sufficiency;
+- evidence integrity failures are often semantic or assurance failures rather than JSON Schema failures.
+
+## Current Guidance Decision
+
+Guidance work is sufficient for the current v0.5.x follow-up cycle.
+
+Added guidance materials include:
+
+- evidence integrity negative test planning;
+- incident-response evidence preservation proposal;
+- incident-response evidence preservation candidate appendix;
+- evidence depth / E5 decision proposal;
+- negative examples and validator fixtures decision proposal;
+- `AAEF-EVD-01` evidence sufficiency review proposal.
+
+Future stable guidance may be extracted later from these temporary documents.
+
+## Close-Readiness Assessment
+
+#165 appears close-ready if the issue scope is interpreted as v0.5.x evidence integrity and tamper-evident evidence follow-up.
+
+Close-ready criteria:
+
+| Criterion | Status |
+| --- | --- |
+| Evidence integrity schema support reviewed | Met |
+| Evidence integrity examples reviewed | Met |
+| Evidence integrity negative testing reviewed | Met |
+| Active `AAEF-EVD-04` reviewed | Met |
+| Incident-response preservation addressed | Met |
+| E5 / evidence depth decision recorded | Met |
+| Negative examples / validator fixtures decision recorded | Met |
+| `AAEF-EVD-01` sufficiency review completed | Met |
+| Remaining work clearly separated | Met |
+
+Suggested close rationale:
+
+> #165 can be closed for the current v0.5.x follow-up cycle because the evidence integrity schema, example, negative testing, incident-response preservation, E5/evidence depth, negative example/fixture, and `AAEF-EVD-01` sufficiency review paths have been addressed or explicitly deferred. Future stable guidance extraction can be tracked separately if needed.
+
+## Remaining Future Work Outside #165
+
+The following may be tracked separately after #165:
+
+- stable evidence integrity guidance extraction;
+- stable incident-response evidence preservation guidance;
+- stable evidence sufficiency reviewer guidance;
+- evidence depth / E5 explanatory guidance;
+- reviewer-facing negative evidence examples;
+- temporary-document consolidation or archival;
+- public-facing summary of evidence integrity decisions.
+
+These are not blockers for closing #165 unless maintainers decide #165 should own stable guidance extraction.
+
+## Non-Goals
+
+This checkpoint does not:
+
+- update active testing procedure CSV;
+- add testing procedure rows;
+- add candidate IDs to active CSV;
+- update the Evidence Event Schema;
+- add evidence examples;
+- add validator fixtures;
+- update `tools/validate_evidence_schema.py`;
+- create an evidence depth certification scale;
+- change control catalog CSV;
+- change human-readable control requirements;
+- change assessment worksheet;
+- change assessment profiles;
+- change external framework mapping CSV;
+- create GitHub issues;
+- close #161, #163, #165, or #167.
+
+It records the consolidation checkpoint before any issue closure decision.


### PR DESCRIPTION
## Summary

This PR adds a temporary v0.5.x issue #165 evidence integrity consolidation checkpoint.

Changes include:

- Add `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`
- Consolidate the current #165 evidence integrity and tamper-evident evidence follow-up sequence
- Record completed workstreams:
  - evidence integrity schema support
  - positive evidence examples
  - evidence integrity negative tests
  - active `AAEF-EVD-04` review
  - incident-response evidence preservation
  - evidence depth / E5 decision
  - negative examples / validator fixtures decision
  - active `AAEF-EVD-01` sufficiency review
- Record that no active CSV, schema, example, or validator change remains required for #165 at this time
- Record close-readiness criteria for #165
- Identify stable guidance extraction and temporary-document consolidation as possible future work outside the current #165 scope
- Update v0.5.x follow-up status and incorporation decision register
- Link the checkpoint from the status directory README, document map, README repository tree, and researcher overview
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation and consolidation checkpoint update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- update `tools/validate_evidence_schema.py`
- create an evidence depth certification scale
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, or #167

## Related

Related follow-up issue:

- #165

Related recent PRs:

- #201
- #202
- #209
- #210
- #211
- #212
- #213
- #214
- #215
- #216
- #217
- #218
- #219
- #220
- #221
- #222
- #223
- #224
- #225

Related active rows:

- `AAEF-EVD-01`
- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x