### PR TITLE
Add v0.5.x tamper-evident evidence contexts incorporation decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a temporary v0.5.x tamper-evident evidence selected contexts incorporation decision.
 - Added a temporary v0.5.x tamper-evident evidence selected contexts candidate appendix.
 - Added a temporary v0.5.x tamper-evident evidence selected contexts proposal.
 - Added a temporary v0.5.x issue #165 evidence integrity consolidation checkpoint.

--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │           ├── v050x-evd01-evidence-sufficiency-limitation-review-proposal.md
 │           ├── v050x-issue-165-evidence-integrity-consolidation-checkpoint.md
 │           ├── v050x-tamper-evident-evidence-selected-contexts-proposal.md
-│           └── v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md
+│           ├── v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md
+│           └── v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -90,6 +90,8 @@ For the v0.5.x tamper-evident evidence selected contexts proposal, see `docs/en/
 
 For the v0.5.x tamper-evident evidence selected contexts candidate appendix, see `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`.
 
+For the v0.5.x tamper-evident evidence selected contexts incorporation decision, see `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
+
 ## Research Motivation
 
 AAEF focuses on a specific problem in agentic AI assurance:

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -165,6 +165,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md` | v0.5.x issue #165 evidence integrity consolidation checkpoint | Temporary status / coordination material |
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md` | v0.5.x tamper-evident evidence selected contexts proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` | v0.5.x tamper-evident evidence selected contexts candidate appendix | Temporary status / coordination material |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` | v0.5.x tamper-evident evidence selected contexts incorporation decision | Temporary status / coordination material |
 
 ## Physical Organization Policy
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -75,3 +75,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`
 - `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md`
 - `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`
+- `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -378,3 +378,9 @@ The proposal starts #166 by identifying contexts where tamper-evident evidence m
 The tamper-evident evidence selected contexts candidate appendix is recorded in `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`.
 
 The appendix expands #166 selected-context planning into concrete candidate scenarios and expectation tiers.
+
+## Tamper-Evident Evidence Selected Contexts Incorporation Decision
+
+The tamper-evident evidence selected contexts incorporation decision is recorded in `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
+
+The decision keeps selected contexts as guidance-only for the current v0.5.x cycle and records that no active CSV, schema, example, or validator change is required at this time for #166.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -793,3 +793,22 @@ Decision status:
 | Related rows | `AAEF-EVD-04`, `AAEF-EVD-01` |
 
 The appendix records concrete required, recommended, optional, and escalation contexts for tamper-evident evidence.
+
+## Tamper-Evident Evidence Selected Contexts Incorporation Decision
+
+A temporary incorporation decision was added in `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
+
+Decision status:
+
+| Area | Decision |
+| --- | --- |
+| Active CSV change | Not required at this time |
+| Evidence Event Schema change | Not required at this time |
+| Example change | Not required at this time |
+| Validator change | Not required at this time |
+| Context tier fields | Not added |
+| Candidate context IDs in active CSV | Not added |
+| Stable guidance extraction | Candidate future work |
+| Primary issue | #166 |
+
+The decision keeps selected-context requirements guidance-only for the current v0.5.x cycle.

--- a/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md
+++ b/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md
@@ -818,3 +818,15 @@ This appendix does not:
 - close #161, #163, #165, #166, or #167.
 
 It records selected-context candidates before any active incorporation decision.
+
+## Incorporation Decision
+
+The selected-context incorporation decision is recorded in `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
+
+Current result:
+
+- selected contexts remain non-normative guidance;
+- no active CSV change is required at this time;
+- no Evidence Event Schema change is required at this time;
+- no evidence example change is required at this time;
+- no validator change is required at this time.

--- a/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
+++ b/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
@@ -1,0 +1,199 @@
+# v0.5.x Tamper-Evident Evidence Selected Contexts Incorporation Decision
+
+**Status:** Temporary, non-normative incorporation decision
+
+## Purpose
+
+This document records the incorporation decision after the v0.5.x tamper-evident evidence selected contexts proposal and candidate appendix.
+
+It follows:
+
+- `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md`
+- `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`
+- `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`
+- `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md`
+- `docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md`
+- `docs/en/status/v050x-follow-up-status.md`
+- `docs/en/status/v050x-incorporation-decision-register.md`
+
+Primary source issue:
+
+- #166 — define tamper-evident evidence requirements for selected contexts
+
+Related active rows:
+
+- `AAEF-EVD-04`
+- `AAEF-EVD-01`
+
+This decision does not update active testing procedures.
+
+It does not update the Evidence Event Schema.
+
+It does not add evidence examples.
+
+It does not add validator fixtures.
+
+It does not close #166 by itself.
+
+## Decision Summary
+
+Selected-context tamper-evident evidence requirements should remain guidance-only for the current v0.5.x follow-up cycle.
+
+Decision:
+
+| Area | Decision |
+| --- | --- |
+| Active CSV change | Not required at this time |
+| Evidence Event Schema change | Not required at this time |
+| Evidence example change | Not required at this time |
+| Validator fixture or behavior change | Not required at this time |
+| Context tier fields | Not added |
+| Candidate context IDs | Not added to active CSV |
+| Stable guidance extraction | Candidate future work |
+| Issue #166 disposition | Continue with status tracking / close-readiness review after this decision |
+
+## Rationale
+
+The selected-context proposal and appendix provide enough detail for review without requiring immediate active artifact changes.
+
+Reasons:
+
+- `AAEF-EVD-04` already covers evidence integrity and tamper-evident evidence at the active testing procedure level.
+- `AAEF-EVD-01` already covers evidence sufficiency and action reconstruction.
+- Selected contexts are useful for guidance, but should not become schema values before implementation feedback.
+- Context-specific tamper-evident evidence requirements may vary by organization, impact, reversibility, dispute likelihood, and implementation maturity.
+- Adding context tiers to the Evidence Event Schema could imply a false certification or scoring model.
+- Adding candidate context IDs to active CSV could overfit the current proposal before the context model stabilizes.
+- Examples may be useful later, but should follow stable selected-context guidance.
+
+## Current Guidance Outcome
+
+The current selected-context guidance identifies:
+
+- contexts where tamper-evident evidence should normally be expected;
+- contexts where it should be strongly recommended;
+- contexts where ordinary evidence may be acceptable unless escalation factors apply;
+- cross-cutting escalation factors that increase evidence integrity expectations;
+- common tamper-evident evidence package expectations;
+- relationship to `AAEF-EVD-04`, `AAEF-EVD-01`, E5/evidence depth, and incident response.
+
+This is sufficient for the current planning stage.
+
+## Active CSV Decision
+
+No active testing procedure CSV refinement is recommended at this time.
+
+`AAEF-EVD-04` should remain mechanism-neutral and context-neutral in the current active CSV.
+
+A later refinement may be considered if reviewers decide that selected-context guidance should be referenced directly in active testing criteria.
+
+## Schema Decision
+
+No Evidence Event Schema change is recommended at this time.
+
+Do not add fields such as:
+
+- `tamper_evident_context`;
+- `context_tier`;
+- `selected_context_id`;
+- `tamper_evident_required`;
+- `tamper_evident_profile`;
+- `evidence_depth_level`;
+- `e5_compliant`.
+
+Those fields may create false precision or imply certification semantics before the selected-context model is stable.
+
+## Example Decision
+
+No new evidence example is required at this time.
+
+Future examples may be useful after the selected-context model stabilizes.
+
+Candidate future examples may include:
+
+- financial action with required tamper-evident evidence;
+- access control change with required tamper-evident evidence;
+- low-impact read-only action with optional evidence expectations;
+- incident-response evidence package with failed or unavailable verification state;
+- approval-gated action where tamper-evident approval-to-execution binding is expected.
+
+## Validator Decision
+
+No validator change is recommended at this time.
+
+The validator should continue to answer structural schema validity questions.
+
+It should not determine whether:
+
+- a selected context applies;
+- tamper-evident evidence is required;
+- evidence is sufficient;
+- evidence is complete;
+- evidence is independently corroborated;
+- an action is high-impact;
+- an action is safe or authorized.
+
+Those decisions belong to assessment, policy, risk classification, and review procedures.
+
+## Guidance-Only Decision
+
+The selected contexts should remain non-normative guidance for now.
+
+Recommended current handling:
+
+1. Keep the selected-context proposal and appendix as temporary v0.5.x coordination material.
+2. Do not incorporate context IDs into active CSV.
+3. Do not add schema fields for selected-context tiers.
+4. Do not create examples until selected-context guidance stabilizes.
+5. Use the appendix as reviewer-facing planning material.
+6. Consider stable guidance extraction later.
+
+## Relationship to #166
+
+This decision advances #166 by resolving the immediate incorporation question.
+
+Current #166 result:
+
+- selected contexts proposal added;
+- selected contexts candidate appendix added;
+- incorporation decision recorded;
+- active CSV, schema, example, and validator changes are not required for the current cycle.
+
+#166 may become close-ready after a status update records this decision.
+
+## Future Work Outside Immediate Incorporation
+
+Future work may include:
+
+- stable selected-context guidance extraction;
+- implementer-facing selected-context examples;
+- reviewer checklist integration;
+- assessment quick-start integration;
+- context-specific evidence package examples;
+- public summary of tamper-evident evidence selected contexts;
+- feedback-driven active CSV refinement.
+
+These should not block the current incorporation decision.
+
+## Non-Goals
+
+This decision does not:
+
+- update active testing procedure CSV;
+- add testing procedure rows;
+- add candidate IDs to active CSV;
+- update the Evidence Event Schema;
+- add evidence examples;
+- add validator fixtures;
+- update `tools/validate_evidence_schema.py`;
+- create an evidence depth certification scale;
+- create selected-context schema fields;
+- change control catalog CSV;
+- change human-readable control requirements;
+- change assessment worksheet;
+- change assessment profiles;
+- change external framework mapping CSV;
+- create GitHub issues;
+- close #161, #163, #165, #166, or #167.
+
+It records the selected-context incorporation decision before any issue closure decision.

--- a/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md
+++ b/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md
@@ -219,3 +219,9 @@ It records selected-context proposal guidance before any active incorporation de
 The tamper-evident evidence selected contexts candidate appendix is recorded in `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`.
 
 The appendix expands the proposal into concrete selected-context candidates, expectation tiers, evidence package candidates, escalation rules, and incorporation considerations.
+
+## Incorporation Decision
+
+The selected-context incorporation decision is recorded in `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
+
+The decision keeps selected-context requirements as guidance-only for the current v0.5.x cycle and does not require active CSV, schema, example, or validator changes.


### PR DESCRIPTION
## Summary

This PR adds a temporary v0.5.x tamper-evident evidence selected contexts incorporation decision.

Changes include:

- Add `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`
- Record that selected-context tamper-evident evidence requirements remain guidance-only for the current v0.5.x cycle
- Record that no active CSV, Evidence Event Schema, evidence example, or validator change is required at this time
- Record that context tier fields and candidate context IDs are not added to active artifacts
- Clarify why selected contexts should not become schema values or active CSV IDs yet
- Update the selected contexts proposal and candidate appendix
- Update v0.5.x follow-up status and incorporation decision register
- Link the decision from the status directory README, document map, README repository tree, and researcher overview
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation and incorporation decision update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- update `tools/validate_evidence_schema.py`
- create an evidence depth certification scale
- create selected-context schema fields
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, #166, or #167

## Related

Related follow-up issue:

- #166

Related recent PRs:

- #227
- #228

Related recently completed issue:

- #165

Related active rows:

- `AAEF-EVD-01`
- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x