### PR TITLE
Update v0.5.x status after tamper-evident contexts decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Updated v0.5.x status after the tamper-evident evidence selected contexts incorporation decision.
+
 ### Added
 
 - Added a temporary v0.5.x tamper-evident evidence selected contexts incorporation decision.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -384,3 +384,28 @@ The appendix expands #166 selected-context planning into concrete candidate scen
 The tamper-evident evidence selected contexts incorporation decision is recorded in `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
 
 The decision keeps selected contexts as guidance-only for the current v0.5.x cycle and records that no active CSV, schema, example, or validator change is required at this time for #166.
+
+## Update after #227, #228, and #229
+
+PRs #227, #228, and #229 completed the current v0.5.x selected-context planning sequence for #166.
+
+Implemented work:
+
+- #227 added `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md`.
+- #228 added `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`.
+- #229 added `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
+
+Current result:
+
+- selected-context tamper-evident evidence requirements remain guidance-only for the current v0.5.x cycle;
+- no active testing procedure CSV change is required at this time;
+- no Evidence Event Schema change is required at this time;
+- no evidence example change is required at this time;
+- no validator change is required at this time;
+- context tier fields are not added;
+- candidate context IDs are not added to active CSV.
+
+Current #166 status:
+
+- #166 is substantially addressed for the current v0.5.x follow-up cycle.
+- #166 remains open for a consolidation / close-readiness checkpoint and any later decision on whether stable selected-context guidance should be extracted from the temporary v0.5.x materials.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -812,3 +812,35 @@ Decision status:
 | Primary issue | #166 |
 
 The decision keeps selected-context requirements guidance-only for the current v0.5.x cycle.
+
+## Update after Tamper-Evident Evidence Selected Contexts Incorporation Decision
+
+After #229, the selected-context tamper-evident evidence incorporation decision for #166 was reviewed.
+
+Decision:
+
+| Area | Decision |
+| --- | --- |
+| Selected-context model | Guidance-only for the current cycle |
+| Active CSV change | Not required at this time |
+| Evidence Event Schema change | Not required at this time |
+| Evidence example change | Not required at this time |
+| Validator change | Not required at this time |
+| Context tier fields | Not added |
+| Candidate context IDs in active CSV | Not added |
+| Stable guidance extraction | Candidate future work |
+| Primary issue | #166 |
+
+Rationale:
+
+- `AAEF-EVD-04` already covers evidence integrity and tamper-evident evidence at the active testing procedure level.
+- `AAEF-EVD-01` already covers evidence sufficiency and action reconstruction.
+- Selected contexts are useful for review and implementation guidance, but should not become schema values or active CSV IDs before feedback.
+- Context-specific evidence requirements may vary by action impact, reversibility, dispute likelihood, delegation complexity, and implementation maturity.
+- Keeping the selected-context model guidance-only avoids false precision, certification confusion, and premature schema or CSV coupling.
+
+Remaining decisions for #166:
+
+- whether to add a consolidation / close-readiness checkpoint;
+- whether stable selected-context guidance should be extracted later;
+- whether selected-context examples should be added in a future cycle.

--- a/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
+++ b/docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
@@ -197,3 +197,19 @@ This decision does not:
 - close #161, #163, #165, #166, or #167.
 
 It records the selected-context incorporation decision before any issue closure decision.
+
+## Status after Initial Incorporation Decision
+
+This decision records the current v0.5.x incorporation outcome for selected-context tamper-evident evidence requirements.
+
+Current incorporation status:
+
+- selected contexts remain non-normative guidance;
+- no active CSV change is required;
+- no Evidence Event Schema change is required;
+- no evidence example change is required;
+- no validator change is required;
+- context tier fields are not added;
+- candidate context IDs are not added to active CSV.
+
+The remaining question is whether #166 can be closed for the current v0.5.x follow-up cycle after a consolidation checkpoint, with stable guidance extraction tracked separately if needed.


### PR DESCRIPTION
## Summary

This PR updates temporary v0.5.x status documents after the tamper-evident evidence selected contexts incorporation decision.

Changes include:

- Update `docs/en/status/v050x-follow-up-status.md`
- Update `docs/en/status/v050x-incorporation-decision-register.md`
- Update `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`
- Record that #227 added the selected contexts proposal
- Record that #228 added the selected contexts candidate appendix
- Record that #229 added the selected contexts incorporation decision
- Record that selected contexts remain guidance-only for the current v0.5.x cycle
- Record that no active CSV, Evidence Event Schema, evidence example, or validator change is required at this time
- Clarify remaining #166 work
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- update `tools/validate_evidence_schema.py`
- create an evidence depth certification scale
- create selected-context schema fields
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, #166, or #167

## Related

Related follow-up issue:

- #166

Related recent PRs:

- #227
- #228
- #229

Related recently completed issue:

- #165

Related active rows:

- `AAEF-EVD-01`
- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x