### PR TITLE
Add v0.5.x issue 166 tamper-evident contexts consolidation checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added a temporary v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint.
+
 ### Changed
 
 - Updated v0.5.x status after the tamper-evident evidence selected contexts incorporation decision.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │           ├── v050x-issue-165-evidence-integrity-consolidation-checkpoint.md
 │           ├── v050x-tamper-evident-evidence-selected-contexts-proposal.md
 │           ├── v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md
-│           └── v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
+│           ├── v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
+│           └── v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -92,6 +92,8 @@ For the v0.5.x tamper-evident evidence selected contexts candidate appendix, see
 
 For the v0.5.x tamper-evident evidence selected contexts incorporation decision, see `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`.
 
+For the v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint, see `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`.
+
 ## Research Motivation
 
 AAEF focuses on a specific problem in agentic AI assurance:

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -166,6 +166,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md` | v0.5.x tamper-evident evidence selected contexts proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` | v0.5.x tamper-evident evidence selected contexts candidate appendix | Temporary status / coordination material |
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` | v0.5.x tamper-evident evidence selected contexts incorporation decision | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md` | v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint | Temporary status / coordination material |
 
 ## Physical Organization Policy
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -76,3 +76,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md`
 - `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`
 - `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`
+- `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -409,3 +409,9 @@ Current #166 status:
 
 - #166 is substantially addressed for the current v0.5.x follow-up cycle.
 - #166 remains open for a consolidation / close-readiness checkpoint and any later decision on whether stable selected-context guidance should be extracted from the temporary v0.5.x materials.
+
+## Issue #166 Tamper-Evident Evidence Contexts Consolidation Checkpoint
+
+The #166 tamper-evident evidence contexts consolidation checkpoint is recorded in `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`.
+
+The checkpoint records that selected-context tamper-evident evidence requirements are substantially addressed for the current v0.5.x follow-up cycle and that #166 appears close-ready if stable selected-context guidance extraction is tracked separately.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -844,3 +844,22 @@ Remaining decisions for #166:
 - whether to add a consolidation / close-readiness checkpoint;
 - whether stable selected-context guidance should be extracted later;
 - whether selected-context examples should be added in a future cycle.
+
+## Issue #166 Tamper-Evident Evidence Contexts Consolidation Checkpoint
+
+A temporary consolidation checkpoint was added in `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`.
+
+Decision status:
+
+| Area | Decision |
+| --- | --- |
+| Active CSV change | Not required |
+| Evidence Event Schema change | Not required |
+| Example change | Not required |
+| Validator change | Not required |
+| Context tier fields | Not added |
+| Candidate context IDs in active CSV | Not added |
+| Stable guidance extraction | Candidate future work |
+| Issue disposition | Close-ready if future guidance extraction is tracked separately |
+
+The checkpoint consolidates the #166 selected-context tamper-evident evidence follow-up decisions for the current v0.5.x cycle.

--- a/docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md
+++ b/docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md
@@ -1,0 +1,211 @@
+# v0.5.x Issue #166 Tamper-Evident Evidence Contexts Consolidation Checkpoint
+
+**Status:** Temporary, non-normative consolidation checkpoint
+
+## Purpose
+
+This document consolidates the v0.5.x follow-up work related to #166: defining tamper-evident evidence requirements for selected contexts.
+
+It records:
+
+- completed work;
+- incorporation decisions;
+- areas intentionally deferred;
+- whether active CSV, schema, example, or validator changes remain necessary;
+- whether #166 is close-ready after the current follow-up sequence.
+
+This document does not update active testing procedures.
+
+It does not update the Evidence Event Schema.
+
+It does not add evidence examples.
+
+It does not add validator fixtures.
+
+It does not close #166 by itself.
+
+## Summary Result
+
+The main #166 workstreams are substantially addressed for the current v0.5.x follow-up cycle.
+
+Current result:
+
+- selected contexts proposal was added;
+- selected contexts candidate appendix was added;
+- selected contexts incorporation decision was added;
+- status was updated after the incorporation decision;
+- selected-context tamper-evident evidence requirements remain guidance-only for the current v0.5.x cycle;
+- no active testing procedure CSV change is required at this time;
+- no Evidence Event Schema change is required at this time;
+- no evidence example change is required at this time;
+- no validator change is required at this time;
+- context tier fields are not added;
+- candidate context IDs are not added to active CSV.
+
+Recommended issue disposition:
+
+- #166 is close-ready after this consolidation checkpoint if maintainers accept that stable selected-context guidance extraction can be tracked separately.
+- If maintainers want to keep #166 open, the only remaining scope should be stable guidance extraction, examples, or future active-artifact refinement after review feedback.
+
+## Completed Workstreams
+
+| Workstream | Status | Key result |
+| --- | --- | --- |
+| Selected contexts proposal | Completed | Candidate required, recommended, and optional contexts were identified. |
+| Selected contexts candidate appendix | Completed | Concrete contexts TE-CXT-01 through TE-CXT-15 were documented. |
+| Incorporation decision | Completed | Selected contexts remain guidance-only for the current cycle. |
+| Active CSV decision | Completed | No active CSV change required at this time. |
+| Schema decision | Completed | No selected-context schema fields added. |
+| Example decision | Completed | No selected-context examples added in this cycle. |
+| Validator decision | Completed | No validator changes required. |
+| Status update | Completed | #166 status was updated after the incorporation decision. |
+| Stable guidance extraction | Pending / future | May be handled after the v0.5.x follow-up cycle. |
+
+## Related PR Sequence
+
+| PR | Result |
+| --- | --- |
+| #227 | Added tamper-evident evidence selected contexts proposal. |
+| #228 | Added tamper-evident evidence selected contexts candidate appendix. |
+| #229 | Added tamper-evident evidence selected contexts incorporation decision. |
+| #230 | Updated status after selected contexts incorporation decision. |
+
+## Current Active CSV Decision
+
+No active testing procedure CSV change is required for #166 at this time.
+
+Rationale:
+
+- `AAEF-EVD-04` already covers evidence integrity and tamper-evident evidence at the active testing procedure level.
+- `AAEF-EVD-01` already covers evidence sufficiency and action reconstruction.
+- Selected contexts are useful for review and guidance, but should not become active CSV IDs before feedback.
+- Context-specific evidence expectations may vary by impact, reversibility, dispute likelihood, delegation complexity, and implementation maturity.
+
+No new testing rows are needed.
+
+No candidate context IDs should be added to active CSV.
+
+## Current Schema Decision
+
+No Evidence Event Schema change is required for #166 at this time.
+
+Do not add selected-context fields such as:
+
+- `tamper_evident_context`;
+- `context_tier`;
+- `selected_context_id`;
+- `tamper_evident_required`;
+- `tamper_evident_profile`.
+
+Rationale:
+
+- context tiers may create false precision;
+- selected-context guidance may evolve after review feedback;
+- schema fields may imply certification or scoring semantics;
+- selected-context applicability is better handled by assessment, policy, and guidance at this stage.
+
+## Current Example Decision
+
+No selected-context evidence example is required for #166 at this time.
+
+Future examples may be useful after selected-context guidance stabilizes.
+
+Candidate future examples may include:
+
+- financial action with required tamper-evident evidence;
+- access control change with required tamper-evident evidence;
+- incident-response evidence package;
+- approval-gated action with approval-to-execution binding;
+- low-impact read-only action with optional evidence expectations.
+
+These are not blockers for closing #166 in the current cycle.
+
+## Current Validator Decision
+
+No validator change is required for #166 at this time.
+
+`tools/validate_evidence_schema.py` should remain focused on structural schema validation.
+
+The validator should not decide:
+
+- whether a selected context applies;
+- whether tamper-evident evidence is required;
+- whether an action is high-impact;
+- whether evidence is sufficient;
+- whether evidence is complete;
+- whether evidence is independently corroborated.
+
+Those decisions belong to assessment, policy, risk classification, and review procedures.
+
+## Current Guidance Decision
+
+Guidance work is sufficient for the current v0.5.x follow-up cycle.
+
+Added guidance materials include:
+
+- selected contexts proposal;
+- selected contexts candidate appendix;
+- selected contexts incorporation decision;
+- status update after incorporation decision.
+
+Future stable guidance may be extracted later from these temporary documents.
+
+## Close-Readiness Assessment
+
+#166 appears close-ready if the issue scope is interpreted as defining selected-context requirements for the current v0.5.x follow-up cycle.
+
+Close-ready criteria:
+
+| Criterion | Status |
+| --- | --- |
+| Selected contexts identified | Met |
+| Required / recommended / optional context candidates documented | Met |
+| Concrete context scenarios documented | Met |
+| Escalation factors documented | Met |
+| Relationship to `AAEF-EVD-04` and `AAEF-EVD-01` documented | Met |
+| Active CSV decision recorded | Met |
+| Schema decision recorded | Met |
+| Example decision recorded | Met |
+| Validator decision recorded | Met |
+| Remaining work clearly separated | Met |
+
+Suggested close rationale:
+
+> #166 can be closed for the current v0.5.x follow-up cycle because selected contexts for tamper-evident evidence have been proposed, expanded into concrete candidates, and reviewed for incorporation. The current decision is to keep selected contexts as guidance-only and not modify active CSV, schema, examples, or validators at this time. Future stable guidance extraction or examples can be tracked separately if needed.
+
+## Remaining Future Work Outside #166
+
+The following may be tracked separately after #166:
+
+- stable selected-context guidance extraction;
+- selected-context implementer examples;
+- reviewer checklist integration;
+- assessment quick-start integration;
+- public-facing summary of selected-context tamper-evident evidence expectations;
+- feedback-driven active CSV refinement;
+- feedback-driven Evidence Event Schema refinement.
+
+These are not blockers for closing #166 unless maintainers decide #166 should own stable guidance extraction.
+
+## Non-Goals
+
+This checkpoint does not:
+
+- update active testing procedure CSV;
+- add testing procedure rows;
+- add candidate IDs to active CSV;
+- update the Evidence Event Schema;
+- add evidence examples;
+- add validator fixtures;
+- update `tools/validate_evidence_schema.py`;
+- create selected-context schema fields;
+- create an evidence depth certification scale;
+- change control catalog CSV;
+- change human-readable control requirements;
+- change assessment worksheet;
+- change assessment profiles;
+- change external framework mapping CSV;
+- create GitHub issues;
+- close #161, #163, #165, #166, or #167.
+
+It records the #166 consolidation checkpoint before any issue closure decision.


### PR DESCRIPTION
## Summary

This PR adds a temporary v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint.

Changes include:

- Add `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`
- Consolidate the current #166 selected-context tamper-evident evidence follow-up sequence
- Record completed workstreams:
  - selected contexts proposal
  - selected contexts candidate appendix
  - selected contexts incorporation decision
  - status update after incorporation decision
- Record that selected contexts remain guidance-only for the current v0.5.x cycle
- Record that no active CSV, Evidence Event Schema, evidence example, or validator change remains required for #166 at this time
- Record close-readiness criteria for #166
- Identify stable selected-context guidance extraction and examples as possible future work outside the current #166 scope
- Update v0.5.x follow-up status and incorporation decision register
- Link the checkpoint from the status directory README, document map, README repository tree, and researcher overview
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation and consolidation checkpoint update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- update `tools/validate_evidence_schema.py`
- create selected-context schema fields
- create an evidence depth certification scale
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- close #161, #163, #165, #166, or #167

## Related

Related follow-up issue:

- #166

Related recent PRs:

- #227
- #228
- #229
- #230

Related recently completed issue:

- #165

Related active rows:

- `AAEF-EVD-01`
- `AAEF-EVD-04`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, v0.5.x