### PR TITLE
Add v0.5.x issue 167 approval quality consolidation checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a temporary v0.5.x issue #167 approval quality consolidation checkpoint.
 - Added a temporary v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ These documents currently remain under `docs/en/` for public review continuity. 
 │           ├── v050x-tamper-evident-evidence-selected-contexts-proposal.md
 │           ├── v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md
 │           ├── v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md
-│           └── v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md
+│           ├── v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md
+│           └── v050x-issue-167-approval-quality-consolidation-checkpoint.md
 │       └── release/
 │           ├── v0.2.0-preparation-checklist.md
 │           ├── v0.3.0-preparation-checklist.md

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -94,6 +94,8 @@ For the v0.5.x tamper-evident evidence selected contexts incorporation decision,
 
 For the v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint, see `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`.
 
+For the v0.5.x issue #167 approval quality consolidation checkpoint, see `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md`.
+
 ## Research Motivation
 
 AAEF focuses on a specific problem in agentic AI assurance:

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -167,6 +167,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` | v0.5.x tamper-evident evidence selected contexts candidate appendix | Temporary status / coordination material |
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` | v0.5.x tamper-evident evidence selected contexts incorporation decision | Temporary status / coordination material |
 | `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md` | v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md` | v0.5.x issue #167 approval quality consolidation checkpoint | Temporary status / coordination material |
 
 ## Physical Organization Policy
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -77,3 +77,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`
 - `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`
 - `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`
+- `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md`

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -415,3 +415,9 @@ Current #166 status:
 The #166 tamper-evident evidence contexts consolidation checkpoint is recorded in `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`.
 
 The checkpoint records that selected-context tamper-evident evidence requirements are substantially addressed for the current v0.5.x follow-up cycle and that #166 appears close-ready if stable selected-context guidance extraction is tracked separately.
+
+## Issue #167 Approval Quality Consolidation Checkpoint
+
+The #167 approval quality consolidation checkpoint is recorded in `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md`.
+
+The checkpoint records that approval quality testing and evidence expectations are substantially addressed for the current v0.5.x follow-up cycle and that #167 appears close-ready if stable approval-quality guidance extraction is tracked separately.

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -863,3 +863,20 @@ Decision status:
 | Issue disposition | Close-ready if future guidance extraction is tracked separately |
 
 The checkpoint consolidates the #166 selected-context tamper-evident evidence follow-up decisions for the current v0.5.x cycle.
+
+## Issue #167 Approval Quality Consolidation Checkpoint
+
+A temporary consolidation checkpoint was added in `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md`.
+
+Decision status:
+
+| Area | Decision |
+| --- | --- |
+| Active CSV change | Not required |
+| Evidence Event Schema change | Not required |
+| Example change | Not required |
+| Validator change | Not required |
+| Stable guidance extraction | Candidate future work |
+| Issue disposition | Close-ready if future guidance extraction is tracked separately |
+
+The checkpoint consolidates the #167 approval quality testing and evidence expectation decisions for the current v0.5.x cycle.

--- a/docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md
+++ b/docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md
@@ -1,0 +1,223 @@
+# v0.5.x Issue #167 Approval Quality Consolidation Checkpoint
+
+**Status:** Temporary, non-normative consolidation checkpoint
+
+## Purpose
+
+This document consolidates the v0.5.x follow-up work related to #167: approval quality testing and evidence expectations.
+
+It records:
+
+- completed work;
+- active testing procedure review outcome;
+- whether active CSV, schema, example, or validator changes remain necessary;
+- whether #167 is close-ready after the current follow-up sequence.
+
+This document does not update active testing procedures.
+
+It does not update the Evidence Event Schema.
+
+It does not add evidence examples.
+
+It does not add validator fixtures.
+
+It does not close #167 by itself.
+
+## Summary Result
+
+The main #167 workstreams are substantially addressed for the current v0.5.x follow-up cycle.
+
+Current result:
+
+- approval quality candidate testing material exists;
+- approval quality CSV refinement proposal exists;
+- active testing procedures have been refined for approval quality and approval-to-execution binding;
+- status has been updated after the approval quality testing refinement;
+- active testing rows already cover meaningful approval, approver context, approval-to-execution binding, mismatch handling, weak approval evidence, and self-reported approval failure;
+- no further active testing procedure CSV change is required at this time;
+- no Evidence Event Schema change is required at this time;
+- no evidence example change is required at this time;
+- no validator change is required at this time.
+
+Recommended issue disposition:
+
+- #167 is close-ready after this consolidation checkpoint if maintainers accept that future stable guidance extraction or examples can be tracked separately.
+- If maintainers want to keep #167 open, the only remaining scope should be stable approval-quality guidance extraction, reviewer-facing examples, or future active-artifact refinement after review feedback.
+
+## Completed Workstreams
+
+| Workstream | Status | Key result |
+| --- | --- | --- |
+| Approval quality candidate testing | Completed | Candidate approval quality scenarios were documented. |
+| Approval quality CSV refinement proposal | Completed | Active testing refinement direction was proposed. |
+| Active testing procedure refinement | Completed | Approval quality and approval-to-execution binding expectations were incorporated into active testing rows. |
+| Status update after refinement | Completed | Follow-up status and incorporation decision register were updated. |
+| Active row review | Completed | Current rows were reviewed and found sufficient for this cycle. |
+| Stable guidance extraction | Pending / future | May be handled after the v0.5.x follow-up cycle. |
+
+## Related PR Sequence
+
+| PR | Result |
+| --- | --- |
+| #198 | Added v0.5.x approval quality CSV refinement proposal. |
+| #199 | Refined approval quality testing procedures. |
+| #200 | Updated v0.5.x status after approval quality testing refinement. |
+
+If an earlier PR added the approval quality testing candidate appendix, that work is treated as part of the completed #167 approval quality planning sequence.
+
+## Current Active CSV Review
+
+The active testing procedure rows were reviewed for approval quality and evidence expectations.
+
+Relevant active rows include:
+
+| Row | Relevance |
+| --- | --- |
+| `AAEF-AUZ-03` | High-risk and critical action approval quality, action-specific approval, canonical action matching, approval state verification, and independent enforcement. |
+| `AAEF-EVD-03` | Approval-to-execution evidence linkage. |
+| `AAEF-HUM-01` | Meaningful approval context and what the approver actually saw. |
+| `AAEF-HUM-02` | Blind approval, rubber-stamping, approval fatigue, batching, and repeated approval detection. |
+| `AAEF-EVD-06` | Reauthorization, additional scope requests, retries, escalation, and approval fatigue indicators. |
+| `AAEF-HUM-03` | Exceptional human intervention and override auditability. |
+| `AAEF-HUM-04` | Break-glass and emergency intervention evidence. |
+
+## Current Coverage Assessment
+
+The active testing procedures sufficiently cover the reviewed #167 approval quality concerns.
+
+| Concern | Review outcome |
+| --- | --- |
+| Approval is not only a checkbox or generic confirmation | Covered |
+| Approver sees relevant action-bound context | Covered |
+| Approval is bound to the executed action | Covered |
+| Approval mismatch or modification after approval is handled | Covered |
+| Self-reported or model-reported approval is insufficient | Covered |
+| Fail and partial criteria exist for weak approval evidence | Covered |
+| Approval fatigue and rubber-stamping risk are addressed | Covered |
+| Reauthorization and repeated request risks are addressed | Covered |
+| Exceptional override and break-glass approval paths are reviewable | Covered |
+
+## Current Active CSV Decision
+
+No further active testing procedure CSV change is required for #167 at this time.
+
+Rationale:
+
+- `AAEF-AUZ-03` already requires meaningful, risk-proportional approval or additional verification before execution.
+- `AAEF-AUZ-03` already requires approval context, canonical action matching, approved scope, execution-boundary verification, and mismatch handling.
+- `AAEF-HUM-01` already requires that approval requests present sufficient action-bound context and record what the approver actually saw.
+- `AAEF-HUM-02` already covers blind approval, rubber-stamping, excessive prompting, batching, and approval fatigue.
+- `AAEF-EVD-03` already links approval evidence to executed or denied actions.
+- Fail conditions already reject generic approvals, broad reusable consent, post-execution approvals, materially different approved actions, agent self-report, UI state alone, and unverified approval state.
+
+No new testing rows are needed.
+
+No candidate IDs should be added to active CSV.
+
+## Current Schema Decision
+
+No Evidence Event Schema change is required for #167 at this time.
+
+Do not add approval-quality-specific schema fields unless later review shows concrete interoperability or assessment needs.
+
+Approval quality should remain primarily an assessment, workflow, authorization, and evidence-linkage concern.
+
+## Current Example Decision
+
+No approval-quality evidence example is required for #167 at this time.
+
+Future examples may be useful after stable guidance extraction.
+
+Candidate future examples may include:
+
+- approval-to-execution mismatch;
+- vague approval prompt for a high-impact action;
+- approval payload modified after approval;
+- model-generated approval summary accepted as evidence;
+- approval state not independently enforced;
+- approval fatigue or repeated reauthorization pattern.
+
+These are not blockers for closing #167 in the current cycle.
+
+## Current Validator Decision
+
+No validator change is required for #167 at this time.
+
+`tools/validate_evidence_schema.py` should remain focused on structural schema validation.
+
+The validator should not decide:
+
+- whether approval was meaningful;
+- whether the approver had enough context;
+- whether approval was risk-proportional;
+- whether approval was bound to execution;
+- whether approval fatigue exists;
+- whether a human decision was appropriate.
+
+Those decisions belong to assessment, workflow review, policy review, authorization review, and evidence review.
+
+## Current Guidance Decision
+
+Guidance work is sufficient for the current v0.5.x follow-up cycle.
+
+Future stable guidance may be extracted later from the temporary approval quality materials and active row wording.
+
+## Close-Readiness Assessment
+
+#167 appears close-ready if the issue scope is interpreted as approval quality testing and evidence expectations for the current v0.5.x follow-up cycle.
+
+Close-ready criteria:
+
+| Criterion | Status |
+| --- | --- |
+| Approval quality candidate material exists | Met |
+| CSV refinement proposal exists | Met |
+| Active testing procedures refined | Met |
+| Approval context expectations covered | Met |
+| Approval-to-execution binding covered | Met |
+| Canonical action matching covered | Met |
+| Approval mismatch handling covered | Met |
+| Weak approval evidence fail conditions covered | Met |
+| Self-reported approval failure covered | Met |
+| Approval fatigue and rubber-stamping covered | Met |
+| Remaining work clearly separated | Met |
+
+Suggested close rationale:
+
+> #167 can be closed for the current v0.5.x follow-up cycle because approval quality testing and evidence expectations have been proposed, incorporated into active testing procedure coverage, reviewed, and found sufficient. Future stable guidance extraction, reviewer-facing examples, or implementation examples can be tracked separately if needed.
+
+## Remaining Future Work Outside #167
+
+The following may be tracked separately after #167:
+
+- stable approval quality guidance extraction;
+- approval-quality reviewer checklist material;
+- approval-to-execution evidence examples;
+- approval fatigue examples;
+- public-facing explanation of meaningful human approval;
+- feedback-driven active CSV refinement.
+
+These are not blockers for closing #167 unless maintainers decide #167 should own stable guidance extraction.
+
+## Non-Goals
+
+This checkpoint does not:
+
+- update active testing procedure CSV;
+- add testing procedure rows;
+- add candidate IDs to active CSV;
+- update the Evidence Event Schema;
+- add evidence examples;
+- add validator fixtures;
+- update `tools/validate_evidence_schema.py`;
+- create approval-quality schema fields;
+- create an evidence depth certification scale;
+- change control catalog CSV;
+- change human-readable control requirements;
+- change assessment worksheet;
+- change assessment profiles;
+- change external framework mapping CSV;
+- create GitHub issues;
+- close #161, #162, #163, #164, #165, #166, or #167.
+
+It records the #167 consolidation checkpoint before any issue closure decision.


### PR DESCRIPTION
## Summary

This PR adds a temporary v0.5.x issue #167 approval quality consolidation checkpoint.

Changes include:

- Add `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md`
- Consolidate the current #167 approval quality testing and evidence expectations follow-up sequence
- Record that approval quality candidate material, CSV refinement proposal, active testing refinement, and status updates are complete
- Record that the active testing procedures already cover:
  - meaningful approval
  - approver context
  - approval-to-execution binding
  - canonical action matching
  - approval mismatch handling
  - weak approval evidence fail conditions
  - self-reported approval failure
  - approval fatigue and rubber-stamping
- Record that no active CSV, Evidence Event Schema, evidence example, or validator change remains required for #167 at this time
- Record close-readiness criteria for #167
- Identify stable approval-quality guidance extraction and examples as possible future work outside the current #167 scope
- Update v0.5.x follow-up status and incorporation decision register
- Link the checkpoint from the status directory README, document map, README repository tree, and researcher overview
- Add an Unreleased changelog entry

## Validation

Validated locally:

    OK: referenced docs/en markdown files exist.

    git diff --check

    OK: evidence schema and examples validated.
    OK: 44 assessment profile mapping rows validated.
    OK: 44 assessment worksheet rows validated.
    OK: 44 controls validated.
    OK: 44 testing procedure rows validated.
    OK: 10 external framework mapping rows validated.

## Impact

This is a status documentation and consolidation checkpoint update.

It does not:

- update active testing procedure CSV
- add testing procedure rows
- add candidate IDs to active CSV
- update the Evidence Event Schema
- add evidence examples
- add validator fixtures
- update `tools/validate_evidence_schema.py`
- create approval-quality schema fields
- create an evidence depth certification scale
- change control catalog CSV
- change human-readable control requirements
- change assessment worksheet
- change assessment profiles
- change external framework mapping CSV
- create GitHub issues
- mark any v0.5.x follow-up issue as completed by automatic PR-closing keywords

## Related

Related follow-up issue:

- #167

Related recent PRs:

- #198
- #199
- #200

Related recently completed issues:

- #165
- #166

Related active rows:

- `AAEF-AUZ-03`
- `AAEF-EVD-03`
- `AAEF-HUM-01`
- `AAEF-HUM-02`
- `AAEF-EVD-06`

Milestone: v0.5.x Follow-up

Labels: documentation, evidence, approval, v0.5.x