### PR TITLE
Update v0.5.x follow-up completion status summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 
 ### Documentation
+- Added v0.5.x follow-up completion summary and cleaned up status/index references after #161 through #167 were closed.
 - Added v0.5.x #164 cross-agent budget propagation consolidation checkpoint and linked it from status materials.
 - Added v0.5.x #163 delegation acceptance/refusal and chain accountability negative tests consolidation checkpoint and linked it from status materials.
 - Added v0.5.x #162 cross-agent capability-scoped delegation consolidation checkpoint and linked it from status materials.

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -54,6 +54,8 @@ For v0.5.x #163 delegation acceptance/refusal and chain accountability consolida
 
 For v0.5.x #164 cross-agent budget propagation consolidation checkpoint, see `docs/en/status/v050x-issue-164-budget-propagation-consolidation-checkpoint.md`.
 
+For the current v0.5.x follow-up completion summary, see `docs/en/status/v050x-follow-up-completion-summary.md`.
+
 For v0.5.x #162 cross-agent capability-scoped delegation consolidation checkpoint, see `docs/en/status/v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md`.
 
 For v0.5.x approval quality testing proposal, see `docs/en/status/v050x-approval-quality-testing-proposal.md`.

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -131,7 +131,8 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 
 | Path | Purpose | Classification |
 | --- | --- | --- |
-| _No matching documents in this category yet._ |  |  |
+| `docs/en/status/v050x-follow-up-completion-summary.md` | v0.5.x follow-up completion summary for #161 through #167 | Temporary status / coordination material |
+| `docs/en/status/v050x-follow-up-status.md` | v0.5.x follow-up status | Temporary status / coordination material |
 | `docs/en/status/v050x-incorporation-decision-register.md` | v0.5.x incorporation direction register | Temporary status / coordination material |
 | `docs/en/status/v050x-testing-candidate-selection.md` | v0.5.x testing candidate selection | Temporary status / coordination material |
 | `docs/en/status/v050x-testing-procedure-candidate-matrix.md` | v0.5.x testing procedure candidate matrix | Temporary status / coordination material |
@@ -140,17 +141,18 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-testing-incorporation-readiness-review.md` | v0.5.x testing incorporation readiness review | Temporary status / coordination material |
 | `docs/en/status/v050x-principal-context-testing-proposal.md` | v0.5.x principal context testing proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-principal-context-testing-candidate-appendix.md` | v0.5.x principal context testing candidate appendix | Temporary status / coordination material |
-| `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md`
-| `docs/en/status/v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md` | v0.5.x issue #161 principal context degradation consolidation checkpoint | Temporary status / coordination material | | v0.5.x principal context testing CSV refinement proposal | Temporary status / coordination material |
+| `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md` | v0.5.x principal context testing CSV refinement proposal | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md` | v0.5.x issue #161 principal context degradation consolidation checkpoint | Temporary status / coordination material |
 | `docs/en/status/v050x-cross-agent-delegation-testing-proposal.md` | v0.5.x cross-agent delegation testing proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md` | v0.5.x cross-agent delegation testing candidate appendix | Temporary status / coordination material |
-| `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md`
-| `docs/en/status/v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md`
-| `docs/en/status/v050x-issue-164-budget-propagation-consolidation-checkpoint.md` | v0.5.x issue #164 cross-agent budget propagation consolidation checkpoint | Temporary status / coordination material | | v0.5.x issue #163 delegation acceptance/refusal and chain accountability negative tests consolidation checkpoint | Temporary status / coordination material |
-| `docs/en/status/v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md` | v0.5.x issue #162 cross-agent capability-scoped delegation consolidation checkpoint | Temporary status / coordination material | | v0.5.x cross-agent delegation CSV refinement proposal | Temporary status / coordination material |
+| `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` | v0.5.x cross-agent delegation CSV refinement proposal | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md` | v0.5.x issue #162 cross-agent capability-scoped delegation consolidation checkpoint | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md` | v0.5.x issue #163 delegation acceptance/refusal and chain accountability negative tests consolidation checkpoint | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-164-budget-propagation-consolidation-checkpoint.md` | v0.5.x issue #164 cross-agent budget propagation consolidation checkpoint | Temporary status / coordination material |
 | `docs/en/status/v050x-approval-quality-testing-proposal.md` | v0.5.x approval quality testing proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` | v0.5.x approval quality testing candidate appendix | Temporary status / coordination material |
 | `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` | v0.5.x approval quality CSV refinement proposal | Temporary status / coordination material |
+| `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md` | v0.5.x issue #167 approval quality consolidation checkpoint | Temporary status / coordination material |
 | `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md` | v0.5.x evidence integrity CSV refinement proposal | Temporary status / coordination material |
 | `docs/en/status/v050x-incorporation-review-checkpoint.md` | v0.5.x incorporation review checkpoint | Temporary status / coordination material |
 | `docs/en/status/v050x-next-phase-track-plan.md` | v0.5.x next phase track plan | Temporary status / coordination material |
@@ -171,7 +173,6 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` | v0.5.x tamper-evident evidence selected contexts candidate appendix | Temporary status / coordination material |
 | `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` | v0.5.x tamper-evident evidence selected contexts incorporation decision | Temporary status / coordination material |
 | `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md` | v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint | Temporary status / coordination material |
-| `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md` | v0.5.x issue #167 approval quality consolidation checkpoint | Temporary status / coordination material |
 
 ## Physical Organization Policy
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -41,44 +41,45 @@ Any normative incorporation must be handled through a later PR that explicitly u
 
 ## Current Status Documents
 
-- `docs/en/status/v050x-follow-up-status.md`
-- `docs/en/status/v050x-incorporation-decision-register.md`
-- `docs/en/status/v050x-testing-candidate-selection.md`
-- `docs/en/status/v050x-testing-procedure-candidate-matrix.md`
-- `docs/en/status/v050x-testing-candidate-mapping.md`
-- `docs/en/status/v050x-testing-draft-pass-fail-criteria.md`
-- `docs/en/status/v050x-testing-incorporation-readiness-review.md`
-- `docs/en/status/v050x-principal-context-testing-proposal.md`
-- `docs/en/status/v050x-principal-context-testing-candidate-appendix.md`
-- `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md
-- [v0.5.x Issue #161 Principal Context Degradation Consolidation Checkpoint](v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md) — records close-readiness for #161 after active testing coverage review.`
-- `docs/en/status/v050x-cross-agent-delegation-testing-proposal.md`
-- `docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md`
-- `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md
-- [v0.5.x Issue #163 Delegation Negative Tests Consolidation Checkpoint](v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md
-- [v0.5.x Issue #164 Budget Propagation Consolidation Checkpoint](v050x-issue-164-budget-propagation-consolidation-checkpoint.md) — records close-readiness for #164 after budget propagation guidance and active coverage review.) — records close-readiness for #163 after negative-test, candidate, and active testing coverage review.
-- [v0.5.x Issue #162 Cross-Agent Capability-Scoped Delegation Consolidation Checkpoint](v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md) — records close-readiness for #162 after active control and testing coverage review.`
-- `docs/en/status/v050x-approval-quality-testing-proposal.md`
-- `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md`
-- `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md`
-- `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md`
-- `docs/en/status/v050x-incorporation-review-checkpoint.md`
-- `docs/en/status/v050x-next-phase-track-plan.md`
-- `docs/en/status/v050x-evidence-schema-and-examples-track-proposal.md`
-- `docs/en/status/v050x-evidence-schema-field-proposal.md`
-- `docs/en/status/v050x-evidence-example-design-proposal.md`
-- `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md`
-- `docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md`
-- `docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md`
-- `docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md`
-- `docs/en/status/v050x-incident-response-evidence-preservation-guidance-proposal.md`
-- `docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md`
-- `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md`
-- `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md`
-- `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md`
-- `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`
-- `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md`
-- `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`
-- `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`
-- `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`
-- `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md`
+- [`docs/en/status/v050x-follow-up-completion-summary.md`](v050x-follow-up-completion-summary.md) — v0.5.x follow-up completion summary for #161 through #167.
+- [`docs/en/status/v050x-follow-up-status.md`](v050x-follow-up-status.md) — v0.5.x follow-up status.
+- [`docs/en/status/v050x-incorporation-decision-register.md`](v050x-incorporation-decision-register.md) — v0.5.x incorporation direction register.
+- [`docs/en/status/v050x-testing-candidate-selection.md`](v050x-testing-candidate-selection.md) — v0.5.x testing candidate selection.
+- [`docs/en/status/v050x-testing-procedure-candidate-matrix.md`](v050x-testing-procedure-candidate-matrix.md) — v0.5.x testing procedure candidate matrix.
+- [`docs/en/status/v050x-testing-candidate-mapping.md`](v050x-testing-candidate-mapping.md) — v0.5.x testing candidate mapping.
+- [`docs/en/status/v050x-testing-draft-pass-fail-criteria.md`](v050x-testing-draft-pass-fail-criteria.md) — v0.5.x testing draft pass/fail criteria.
+- [`docs/en/status/v050x-testing-incorporation-readiness-review.md`](v050x-testing-incorporation-readiness-review.md) — v0.5.x testing incorporation readiness review.
+- [`docs/en/status/v050x-principal-context-testing-proposal.md`](v050x-principal-context-testing-proposal.md) — v0.5.x principal context testing proposal.
+- [`docs/en/status/v050x-principal-context-testing-candidate-appendix.md`](v050x-principal-context-testing-candidate-appendix.md) — v0.5.x principal context testing candidate appendix.
+- [`docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md`](v050x-principal-context-testing-csv-refinement-proposal.md) — v0.5.x principal context testing CSV refinement proposal.
+- [`docs/en/status/v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md`](v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md) — v0.5.x issue #161 principal context degradation consolidation checkpoint.
+- [`docs/en/status/v050x-cross-agent-delegation-testing-proposal.md`](v050x-cross-agent-delegation-testing-proposal.md) — v0.5.x cross-agent delegation testing proposal.
+- [`docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md`](v050x-cross-agent-delegation-testing-candidate-appendix.md) — v0.5.x cross-agent delegation testing candidate appendix.
+- [`docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md`](v050x-cross-agent-delegation-csv-refinement-proposal.md) — v0.5.x cross-agent delegation CSV refinement proposal.
+- [`docs/en/status/v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md`](v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md) — v0.5.x issue #162 cross-agent capability-scoped delegation consolidation checkpoint.
+- [`docs/en/status/v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md`](v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md) — v0.5.x issue #163 delegation acceptance/refusal and chain accountability negative tests consolidation checkpoint.
+- [`docs/en/status/v050x-issue-164-budget-propagation-consolidation-checkpoint.md`](v050x-issue-164-budget-propagation-consolidation-checkpoint.md) — v0.5.x issue #164 cross-agent budget propagation consolidation checkpoint.
+- [`docs/en/status/v050x-approval-quality-testing-proposal.md`](v050x-approval-quality-testing-proposal.md) — v0.5.x approval quality testing proposal.
+- [`docs/en/status/v050x-approval-quality-testing-candidate-appendix.md`](v050x-approval-quality-testing-candidate-appendix.md) — v0.5.x approval quality testing candidate appendix.
+- [`docs/en/status/v050x-approval-quality-csv-refinement-proposal.md`](v050x-approval-quality-csv-refinement-proposal.md) — v0.5.x approval quality CSV refinement proposal.
+- [`docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md`](v050x-issue-167-approval-quality-consolidation-checkpoint.md) — v0.5.x issue #167 approval quality consolidation checkpoint.
+- [`docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md`](v050x-evidence-integrity-csv-refinement-proposal.md) — v0.5.x evidence integrity CSV refinement proposal.
+- [`docs/en/status/v050x-incorporation-review-checkpoint.md`](v050x-incorporation-review-checkpoint.md) — v0.5.x incorporation review checkpoint.
+- [`docs/en/status/v050x-next-phase-track-plan.md`](v050x-next-phase-track-plan.md) — v0.5.x next phase track plan.
+- [`docs/en/status/v050x-evidence-schema-and-examples-track-proposal.md`](v050x-evidence-schema-and-examples-track-proposal.md) — v0.5.x evidence schema and examples track proposal.
+- [`docs/en/status/v050x-evidence-schema-field-proposal.md`](v050x-evidence-schema-field-proposal.md) — v0.5.x evidence schema field proposal.
+- [`docs/en/status/v050x-evidence-example-design-proposal.md`](v050x-evidence-example-design-proposal.md) — v0.5.x evidence example design proposal.
+- [`docs/en/status/v050x-evidence-schema-example-implementation-readiness.md`](v050x-evidence-schema-example-implementation-readiness.md) — v0.5.x evidence schema/example implementation readiness review.
+- [`docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md`](v050x-evidence-integrity-negative-tests-track-proposal.md) — v0.5.x evidence integrity negative tests track proposal.
+- [`docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md`](v050x-evidence-integrity-negative-tests-candidate-appendix.md) — v0.5.x evidence integrity negative tests candidate appendix.
+- [`docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md`](v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md) — v0.5.x evidence integrity negative tests CSV refinement proposal.
+- [`docs/en/status/v050x-incident-response-evidence-preservation-guidance-proposal.md`](v050x-incident-response-evidence-preservation-guidance-proposal.md) — v0.5.x incident-response evidence preservation guidance proposal.
+- [`docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md`](v050x-incident-response-evidence-preservation-candidate-appendix.md) — v0.5.x incident-response evidence preservation candidate appendix.
+- [`docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md`](v050x-evidence-depth-e5-profile-decision-proposal.md) — v0.5.x evidence depth and E5 profile decision proposal.
+- [`docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md`](v050x-negative-evidence-examples-fixtures-decision-proposal.md) — v0.5.x negative evidence examples and validator fixtures decision proposal.
+- [`docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md`](v050x-evd01-evidence-sufficiency-limitation-review-proposal.md) — v0.5.x AAEF-EVD-01 evidence sufficiency and limitation review proposal.
+- [`docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md`](v050x-issue-165-evidence-integrity-consolidation-checkpoint.md) — v0.5.x issue #165 evidence integrity consolidation checkpoint.
+- [`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md`](v050x-tamper-evident-evidence-selected-contexts-proposal.md) — v0.5.x tamper-evident evidence selected contexts proposal.
+- [`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md`](v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md) — v0.5.x tamper-evident evidence selected contexts candidate appendix.
+- [`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md`](v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md) — v0.5.x tamper-evident evidence selected contexts incorporation decision.
+- [`docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md`](v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md) — v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint.

--- a/docs/en/status/v050x-follow-up-completion-summary.md
+++ b/docs/en/status/v050x-follow-up-completion-summary.md
@@ -1,0 +1,79 @@
+# v0.5.x Follow-up Completion Summary
+
+**Status:** Current completion summary
+**Scope:** v0.5.x follow-up issues #161 through #167
+**Milestone:** v0.5.x Follow-up
+**Type:** Temporary status / coordination material
+
+## Purpose
+
+This document summarizes the current completion state of the v0.5.x follow-up work.
+
+It supersedes earlier interim status notes that described #161 through #167 as open, partially incorporated, or pending consolidation.
+
+The current state is:
+
+- #161 through #167 are complete for the current v0.5.x follow-up cycle.
+- #3 remains open as the umbrella roadmap and discussion issue for Cross-Agent and Cross-Domain Authority.
+- Future work should be tracked separately if selected guidance is promoted into stable controls, active testing, schema fields, examples, assessment profiles, implementation guidance, or a future release milestone.
+
+## Completed Follow-up Issues
+
+| Issue | Topic | Completion PR / checkpoint | Current disposition |
+| --- | --- | --- | --- |
+| #161 | Principal context degradation testing criteria | #233 / `v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md` | Completed and closed |
+| #162 | Cross-agent capability-scoped delegation controls | #234 / `v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md` | Completed and closed |
+| #163 | Delegation acceptance/refusal and chain accountability negative tests | #235 / `v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md` | Completed and closed |
+| #164 | Cross-agent budget propagation guidance | #236 / `v050x-issue-164-budget-propagation-consolidation-checkpoint.md` | Completed and closed |
+| #165 | Evidence integrity and tamper-evident evidence follow-up | #226 / `v050x-issue-165-evidence-integrity-consolidation-checkpoint.md` | Completed and closed |
+| #166 | Tamper-evident evidence requirements for selected contexts | #231 / `v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md` | Completed and closed |
+| #167 | Approval quality testing and evidence expectations | #232 / `v050x-issue-167-approval-quality-consolidation-checkpoint.md` | Completed and closed |
+
+## Current Cross-Agent Authority Disposition
+
+The v0.5.x cross-agent authority follow-up threads are complete for the current cycle.
+
+Current decisions:
+
+- capability-scoped cross-agent delegation remains an existing-control refinement and guidance concept for this cycle;
+- delegation acceptance/refusal, refusal propagation, receiving-side validation, and chain accountability negative tests are defined and supported by active testing coverage;
+- cross-agent budget and resource propagation remains non-normative guidance and an existing-control refinement candidate;
+- no new dedicated cross-agent control domain is added in this cycle;
+- no new dedicated A2A / XDA control IDs are added in this cycle;
+- no immediate Evidence Event Schema, evidence example, validator, assessment worksheet, assessment profile, or external mapping change is required for #162, #163, or #164.
+
+The umbrella issue #3 remains open for broader roadmap discussion.
+
+## Current Evidence / Approval / Context Disposition
+
+The v0.5.x evidence, approval, and principal-context follow-up threads are complete for the current cycle.
+
+Current decisions:
+
+- principal context degradation testing criteria are sufficiently covered by current active testing rows for this cycle;
+- approval quality testing and evidence expectations are sufficiently covered by current active testing rows for this cycle;
+- evidence integrity, tamper-evident evidence, selected-context requirements, incident-response preservation, E5/evidence depth treatment, negative examples/fixtures, and `AAEF-EVD-01` sufficiency review have been addressed or explicitly deferred for separate future work;
+- no further active CSV, schema, example, validator, profile, mapping, or assessment worksheet change is required for #161, #165, #166, or #167 at this time.
+
+## Open Umbrella
+
+#3 remains open as the broader Cross-Agent and Cross-Domain Authority roadmap / discussion issue.
+
+Future work may decide whether selected concepts should become:
+
+- a dedicated cross-agent / cross-domain control domain;
+- new A2A / XDA control IDs;
+- active testing procedure refinements;
+- Evidence Event Schema fields;
+- cross-agent evidence examples;
+- assessment profile guidance;
+- implementation guidance;
+- or a future release milestone.
+
+## Historical Notes
+
+Earlier v0.5.x status documents may describe #161 through #167 as open, partially incorporated, or pending consolidation.
+
+Those statements should be read as historical status at the time they were written.
+
+The current completion state is recorded in this document and in the individual consolidation checkpoint files.

--- a/docs/en/status/v050x-follow-up-status.md
+++ b/docs/en/status/v050x-follow-up-status.md
@@ -1,5 +1,28 @@
 # v0.5.x Follow-up Status
 
+## Current Completion Status
+
+The v0.5.x follow-up issues #161 through #167 are complete for the current follow-up cycle.
+
+Current disposition:
+
+| Issue | Topic | Completion PR | Current status |
+| --- | --- | --- | --- |
+| #161 | Principal context degradation testing criteria | #233 | Completed and closed |
+| #162 | Capability-scoped cross-agent delegation controls | #234 | Completed and closed |
+| #163 | Delegation acceptance/refusal and chain accountability negative tests | #235 | Completed and closed |
+| #164 | Cross-agent budget propagation guidance | #236 | Completed and closed |
+| #165 | Evidence integrity and tamper-evident evidence follow-up | #226 | Completed and closed |
+| #166 | Tamper-evident evidence requirements for selected contexts | #231 | Completed and closed |
+| #167 | Approval quality testing and evidence expectations | #232 | Completed and closed |
+
+#3 remains open as the umbrella roadmap and discussion issue for Cross-Agent and Cross-Domain Authority.
+
+For the consolidated current state, see `docs/en/status/v050x-follow-up-completion-summary.md`.
+
+Older sections in this document may describe intermediate states before the consolidation checkpoints were merged and the related issues were closed.
+
+
 **Status:** Temporary, non-normative follow-up status document
 
 ## Purpose
@@ -41,11 +64,11 @@ They do not update:
 | #166 | Tamper-evident evidence requirements for selected contexts | PR #176 | `docs/en/61-tamper-evident-evidence-requirements.md` | Decide which contexts should require tamper-evident evidence and whether evidence fields, E5 examples, or testing candidates should be added. |
 | #167 | Approval quality testing and evidence expectations | PR #177 | `docs/en/62-approval-quality-testing-guidance.md` | Decide which approval quality tests become testing procedure candidates, assessment profile inputs, evidence/schema candidates, or HUM control refinements. |
 
-## Why the Issues Remain Open
+## Historical: Why the Issues Initially Remained Open
 
 The initial guidance/testing pass is complete.
 
-The issues remain open because incorporation decisions are still pending.
+At the time this section was written, the issues remained open because incorporation decisions were still pending.
 
 The next step is not only to ask whether the concepts are useful, but to decide where each concept belongs.
 
@@ -126,7 +149,7 @@ The active testing procedure CSV was refined for:
 
 This update partially addresses #161.
 
-#161 remains open because additional principal context degradation work is still pending, including:
+At that stage, #161 remained open because additional principal context degradation work is still pending, including:
 
 - material task drift thresholds;
 - retry-after-denial correlation;
@@ -145,7 +168,7 @@ The active testing procedure CSV was refined for:
 
 This update partially addresses #163.
 
-#163 remains open because additional cross-agent delegation work is still pending, including:
+At that stage, #163 remained open because additional cross-agent delegation work is still pending, including:
 
 - capability-scoped delegation refinement for `AAEF-DEL-02`;
 - fire-and-forget delegation and explicit acceptance behavior;
@@ -165,7 +188,7 @@ The active testing procedure CSV was refined for:
 
 This update partially addresses #167.
 
-#167 remains open because additional approval quality work is still pending, including:
+At that stage, #167 remained open because additional approval quality work is still pending, including:
 
 - draft-vs-execute approval operation-class refinement;
 - post-approval payload modification and materiality criteria;
@@ -186,7 +209,7 @@ The existing active testing procedure row already provides substantial coverage:
 
 This update records #165 as already substantially represented in the current active testing procedure model through `AAEF-EVD-04`.
 
-#165 remains open because additional evidence integrity work is still pending, including:
+At that stage, #165 remained open because additional evidence integrity work is still pending, including:
 
 - deciding whether evidence integrity fields should be added to the Evidence Event Schema;
 - defining E5 or higher-depth examples using tamper-evident evidence;
@@ -203,10 +226,10 @@ After #202, the first incorporation review cycle for #161, #163, #165, and #167 
 
 Current checkpoint:
 
-- #161 principal context — first active CSV refinement incorporated; issue remains open.
-- #163 cross-agent delegation — first active CSV refinement incorporated; issue remains open.
-- #165 evidence integrity — substantially represented by existing `AAEF-EVD-04`; no immediate active CSV change required; issue remains open.
-- #167 approval quality — first active CSV refinement incorporated; issue remains open.
+- #161 principal context — first active CSV refinement incorporated; issue remained open at that stage.
+- #163 cross-agent delegation — first active CSV refinement incorporated; issue remained open at that stage.
+- #165 evidence integrity — substantially represented by existing `AAEF-EVD-04`; no immediate active CSV change required; issue remained open at that stage.
+- #167 approval quality — first active CSV refinement incorporated; issue remained open at that stage.
 
 For the consolidated checkpoint, see `docs/en/status/v050x-incorporation-review-checkpoint.md`.
 
@@ -230,10 +253,10 @@ This completes the first schema-first, example-follow-up implementation sequence
 
 Current issue status:
 
-- #165 remains open because evidence integrity negative tests, replay/reordering/selective omission tests, incident-response evidence preservation guidance, and any evidence-depth/profile decisions remain pending.
-- #167 remains open because approval semantics, draft-vs-execute approval, post-approval modification, approval fatigue, and related HUM/AUZ/EVD testing decisions remain pending.
-- #161 remains open because principal context freshness/degradation schema or profile treatment was explicitly deferred.
-- #163 remains open because delegation lineage and receiving-side validation schema treatment was explicitly deferred.
+- At that stage, #165 remained open because evidence integrity negative tests, replay/reordering/selective omission tests, incident-response evidence preservation guidance, and any evidence-depth/profile decisions remain pending.
+- At that stage, #167 remained open because approval semantics, draft-vs-execute approval, post-approval modification, approval fatigue, and related HUM/AUZ/EVD testing decisions remain pending.
+- At that stage, #161 remained open because principal context freshness/degradation schema or profile treatment was explicitly deferred.
+- At that stage, #163 remained open because delegation lineage and receiving-side validation schema treatment was explicitly deferred.
 
 No active testing procedure CSV changes were made in #209, #210, or #211.
 
@@ -249,7 +272,7 @@ Review result:
 
 Current issue status:
 
-- #165 remains open because incident-response evidence preservation guidance, evidence depth/profile decisions, possible evidence integrity negative examples or validator fixtures, and later evidence sufficiency / limitation review remain pending.
+- At that stage, #165 remained open because incident-response evidence preservation guidance, evidence depth/profile decisions, possible evidence integrity negative examples or validator fixtures, and later evidence sufficiency / limitation review remain pending.
 - `AAEF-EVD-04` does not need immediate active CSV modification based on the current review.
 
 ## Incident-Response Evidence Preservation Guidance Proposal
@@ -284,7 +307,7 @@ Current result:
 Current #165 status:
 
 - The incident-response evidence preservation portion is substantially addressed for the current v0.5.x follow-up cycle.
-- #165 remains open because evidence depth / E5 profile decisions, possible negative examples or validator fixtures, possible `AAEF-EVD-01` evidence sufficiency / limitation review, and temporary-document consolidation remain pending.
+- At that stage, #165 remained open because evidence depth / E5 profile decisions, possible negative examples or validator fixtures, possible `AAEF-EVD-01` evidence sufficiency / limitation review, and temporary-document consolidation remain pending.
 
 ## Evidence Depth and E5 Profile Decision Proposal
 
@@ -311,7 +334,7 @@ Current result:
 Current #165 status:
 
 - Evidence integrity schema support, integrity-focused example, evidence integrity negative test planning, incident-response preservation guidance, incident-response preservation candidate coverage, and E5/evidence depth decision work are now substantially addressed for the current v0.5.x follow-up cycle.
-- #165 remains open because possible negative examples or validator fixtures, possible `AAEF-EVD-01` evidence sufficiency / limitation review, and temporary-document consolidation remain pending.
+- At that stage, #165 remained open because possible negative examples or validator fixtures, possible `AAEF-EVD-01` evidence sufficiency / limitation review, and temporary-document consolidation remain pending.
 
 ## Negative Evidence Examples and Validator Fixtures Decision Proposal
 
@@ -338,7 +361,7 @@ Current result:
 Current #165 status:
 
 - Evidence integrity schema support, integrity-focused example, evidence integrity negative test planning, incident-response preservation guidance, incident-response preservation candidate coverage, E5/evidence depth decision work, and negative example / validator fixture decision work are now substantially addressed for the current v0.5.x follow-up cycle.
-- #165 remains open because possible `AAEF-EVD-01` evidence sufficiency / limitation review and temporary-document consolidation remain pending.
+- At that stage, #165 remained open because possible `AAEF-EVD-01` evidence sufficiency / limitation review and temporary-document consolidation remain pending.
 
 ## AAEF-EVD-01 Evidence Sufficiency and Limitation Review Proposal
 

--- a/docs/en/status/v050x-incorporation-decision-register.md
+++ b/docs/en/status/v050x-incorporation-decision-register.md
@@ -1,5 +1,28 @@
 # v0.5.x Incorporation Decision Register
 
+## Current Completion Status
+
+The incorporation decisions for #161 through #167 have been resolved for the current v0.5.x follow-up cycle.
+
+Current disposition:
+
+| Issue | Topic | Completion PR | Current status |
+| --- | --- | --- | --- |
+| #161 | Principal context degradation | #233 | Completed and closed |
+| #162 | Capability-scoped cross-agent delegation | #234 | Completed and closed |
+| #163 | Delegation acceptance/refusal and chain accountability | #235 | Completed and closed |
+| #164 | Cross-agent budget propagation | #236 | Completed and closed |
+| #165 | Evidence integrity and tamper-evident evidence | #226 | Completed and closed |
+| #166 | Tamper-evident evidence selected contexts | #231 | Completed and closed |
+| #167 | Approval quality | #232 | Completed and closed |
+
+#3 remains open as the umbrella roadmap and discussion issue for Cross-Agent and Cross-Domain Authority.
+
+For the consolidated current state, see `docs/en/status/v050x-follow-up-completion-summary.md`.
+
+Older entries in this register may describe intermediate incorporation states before the consolidation checkpoints were merged and the related issues were closed.
+
+
 **Status:** Temporary, non-normative incorporation decision register
 
 ## Purpose
@@ -154,7 +177,7 @@ Recommended next step:
 
 Closure condition:
 
-- this issue should remain open until selected tests are either incorporated, split into testing issues, or explicitly deferred.
+- at that stage, this issue was kept open until selected tests are either incorporated, split into testing issues, or explicitly deferred.
 
 ### #162 — Capability-scoped cross-agent delegation controls
 
@@ -171,7 +194,7 @@ Recommended next step:
 
 Closure condition:
 
-- this issue should remain open until a control refinement proposal, deferral decision, or split issue set exists.
+- at that stage, this issue was kept open until a control refinement proposal, deferral decision, or split issue set exists.
 
 ### #163 — Delegation acceptance/refusal and chain accountability negative tests
 
@@ -187,7 +210,7 @@ Recommended next step:
 
 Closure condition:
 
-- this issue should remain open until the test subset is selected, split, or deferred.
+- at that stage, this issue was kept open until the test subset is selected, split, or deferred.
 
 ### #164 — Cross-agent budget propagation guidance
 
@@ -204,7 +227,7 @@ Recommended next step:
 
 Closure condition:
 
-- this issue should remain open until selected-context expectations are defined or deferred.
+- at that stage, this issue was kept open until selected-context expectations are defined or deferred.
 
 ### #165 — Evidence integrity levels for high-impact and audit-grade profiles
 
@@ -220,7 +243,7 @@ Recommended next step:
 
 Closure condition:
 
-- this issue should remain open until assessment profile impact is incorporated, split, or deferred.
+- at that stage, this issue was kept open until assessment profile impact is incorporated, split, or deferred.
 
 ### #166 — Tamper-evident evidence requirements for selected contexts
 
@@ -237,7 +260,7 @@ Recommended next step:
 
 Closure condition:
 
-- this issue should remain open until selected contexts and schema/testing follow-ups are decided.
+- at that stage, this issue was kept open until selected contexts and schema/testing follow-ups are decided.
 
 ### #167 — Approval quality testing and evidence expectations
 
@@ -253,11 +276,11 @@ Recommended next step:
 
 Closure condition:
 
-- this issue should remain open until selected tests, evidence expectations, HUM refinements, or deferrals are created.
+- at that stage, this issue was kept open until selected tests, evidence expectations, HUM refinements, or deferrals are created.
 
 ## Cross-Cutting Decisions
 
-### Do not close #161 through #167 yet
+### Historical: do not close #161 through #167 yet
 
 The initial guidance/testing pass is complete, but incorporation decisions remain active.
 
@@ -300,7 +323,7 @@ The status tracker answers:
 
 - what has been completed;
 - which documents exist;
-- why issues remain open.
+- why issues remained open at that stage.
 
 This register answers:
 
@@ -462,10 +485,10 @@ The current incorporation decisions are:
 
 | Issue | Topic | Incorporation decision | Active artifact result | Status |
 | --- | --- | --- | --- | --- |
-| #161 | Principal context | Partially incorporate into existing active testing rows | Active testing procedure CSV refined; consolidation checkpoint prepared | Close-ready after checkpoint merge |
-| #163 | Cross-agent delegation | Partially incorporate into existing active DEL testing rows | Active testing procedure CSV refined | Open |
-| #165 | Evidence integrity | Treat as substantially represented by `AAEF-EVD-04` for the first step | No immediate active CSV change | Open |
-| #167 | Approval quality | Partially incorporate into existing active HUM/AUZ testing rows | Active testing procedure CSV refined | Open |
+| #161 | Principal context | Completed for current cycle | Consolidation checkpoint merged in #233 | Closed |
+| #163 | Cross-agent delegation | Completed for current cycle | Consolidation checkpoint merged in #235 | Closed |
+| #165 | Evidence integrity | Completed for current cycle | Consolidation checkpoint merged in #226 | Closed |
+| #167 | Approval quality | Completed for current cycle | Consolidation checkpoint merged in #232 | Closed |
 
 The consolidated checkpoint is recorded in `docs/en/status/v050x-incorporation-review-checkpoint.md`.
 

--- a/docs/en/status/v050x-incorporation-review-checkpoint.md
+++ b/docs/en/status/v050x-incorporation-review-checkpoint.md
@@ -1,5 +1,8 @@
 # v0.5.x Incorporation Review Checkpoint
 
+> **Historical note:** This document records an earlier v0.5.x planning or incorporation state. The current completion state for #161 through #167 is summarized in `docs/en/status/v050x-follow-up-completion-summary.md`.
+
+
 **Status:** Temporary, non-normative incorporation checkpoint
 
 ## Purpose

--- a/docs/en/status/v050x-next-phase-track-plan.md
+++ b/docs/en/status/v050x-next-phase-track-plan.md
@@ -1,5 +1,8 @@
 # v0.5.x Next Phase Track Plan
 
+> **Historical note:** This document records an earlier v0.5.x planning or incorporation state. The current completion state for #161 through #167 is summarized in `docs/en/status/v050x-follow-up-completion-summary.md`.
+
+
 **Status:** Temporary, non-normative planning and coordination document
 
 ## Purpose


### PR DESCRIPTION
## Summary

- Add `docs/en/status/v050x-follow-up-completion-summary.md`.
- Record the current completion state for v0.5.x follow-up issues #161 through #167.
- Record that #3 remains open as the Cross-Agent and Cross-Domain Authority umbrella roadmap / discussion issue.
- Update `docs/en/status/v050x-follow-up-status.md` with a current completion status section.
- Update `docs/en/status/v050x-incorporation-decision-register.md` with a current completion status section.
- Add historical notes to earlier interim planning/status documents.
- Fix status document index entries in `docs/en/status/README.md`.
- Fix status document rows in `docs/en/document-map.md`.
- Add a researcher overview pointer to the current completion summary.

## Validation

- [x] `git diff --check`
- [x] `python tools/validate_evidence_schema.py`
- [x] `python tools/validate_assessment_profiles.py`
- [x] `python tools/validate_assessment_worksheet.py`
- [x] `python tools/validate_control_catalog.py`
- [x] `python tools/validate_testing_procedures.py`
- [x] `python tools/validate_external_mappings.py`

## Impact

This PR is status documentation and index cleanup only.

It does not:

- close #3;
- add new controls;
- update active testing procedure CSV rows;
- update the Evidence Event Schema;
- add evidence examples;
- add validator fixtures;
- update assessment worksheet rows;
- update assessment profiles;
- update external framework mappings;
- change the current AAEF control and assessment baseline.

## Related

- Umbrella roadmap issue: #3
- Completed follow-up issues: #161, #162, #163, #164, #165, #166, #167
- Related consolidation PRs: #226, #231, #232, #233, #234, #235, #236
- Milestone: v0.5.x Follow-up
- Labels: documentation, roadmap, v0.5.x
