### PR TITLE
Validate numbered document map coverage

### DIFF
--- a/tools/validate_markdown_indexes.py
+++ b/tools/validate_markdown_indexes.py
@@ -252,10 +252,34 @@ def validate_document_map_status_coverage(errors: list[str]) -> None:
         )
 
 
+
+def validate_numbered_docs_registered(errors: list[str]) -> None:
+    """Ensure top-level numbered docs/en/*.md files are listed in document-map.md."""
+    document_map_text = DOCUMENT_MAP.read_text(encoding="utf-8")
+    registered_paths = set(
+        re.findall(r"`(docs/en/[^`]+\.md)`", document_map_text)
+    )
+
+    numbered_doc_pattern = re.compile(r"^\d{2}-.*\.md$")
+    numbered_docs = sorted(
+        path
+        for path in (REPO_ROOT / "docs" / "en").glob("*.md")
+        if numbered_doc_pattern.match(path.name)
+    )
+
+    for numbered_doc in numbered_docs:
+        expected = f"docs/en/{numbered_doc.name}"
+        if expected not in registered_paths:
+            errors.append(
+                f"{rel(DOCUMENT_MAP)}: missing document-map row for numbered document {expected}."
+            )
+
+
 def main() -> int:
     errors: list[str] = []
 
     validate_document_map(errors)
+    validate_numbered_docs_registered(errors)
     validate_status_readme(errors)
     validate_document_map_status_coverage(errors)
 


### PR DESCRIPTION
## Summary

This PR strengthens `tools/validate_markdown_indexes.py` so top-level numbered English documents under `docs/en/` must be represented in `docs/en/document-map.md`.

This follows PR #254, which registered the previously missing numbered document entries. The purpose of this PR is to prevent future regressions.

## Changes

- Adds numbered document map coverage validation to `tools/validate_markdown_indexes.py`
- Detects missing `docs/en/NN-*.md` entries in `docs/en/document-map.md`
- Keeps the validation limited to top-level numbered English docs

## Scope

This PR is tooling-only.

It does not:

- change active controls
- change the current control and assessment baseline
- change document content
- change schemas, CSV artifacts, examples, or mappings
- promote non-normative planning material into active requirements

## Validation

The following validation passed:

    py tools/validate_markdown_indexes.py

Negative smoke test:
- Temporarily removed the `docs/en/07-control-requirements.md` document-map row.
- Confirmed the validator failed with the expected numbered-doc coverage error.
- Restored `docs/en/document-map.md`.
- Re-ran validation successfully.

## Related review findings

Prevents recurrence of:

- F-01: document-map missing core docs
- F-05: document-map missing non-normative planning / guidance docs

## Related PRs

Follow-up to #254.

## Related issues

Related to #241.
