### PR TITLE
Clean up Unreleased changelog for v0.6.0 planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,85 +2,48 @@
 
 ## Unreleased
 
-### Planning and Status
-- Added v0.5.x follow-up completion summary and cleaned up status/index references after #161 through #167 were closed.
-- Added v0.5.x #164 cross-agent budget propagation consolidation checkpoint and linked it from status materials.
-- Added v0.5.x #162 cross-agent capability-scoped delegation consolidation checkpoint and linked it from status materials.
-- Added a temporary v0.5.x issue #167 approval quality consolidation checkpoint.
-- Added a temporary v0.5.x issue #166 tamper-evident evidence contexts consolidation checkpoint.
-- Added a temporary v0.5.x issue #165 evidence integrity consolidation checkpoint.
-- Updated v0.5.x status after reviewing evidence integrity testing procedure coverage.
-- Updated v0.5.x status documents after the first evidence schema and example implementation wave.
-- Added a temporary v0.5.x incorporation review checkpoint for #161, #163, #165, and #167.
-- Updated v0.5.x status documents after the evidence integrity CSV refinement proposal review.
-- Added temporary v0.5.x follow-up status tracking under `docs/en/status/`.
-- Added a temporary v0.5.x tamper-evident evidence selected contexts candidate appendix.
-- Added a temporary v0.5.x next phase track plan.
-- Added a temporary v0.5.x evidence integrity CSV refinement proposal.
-- Added a temporary v0.5.x approval quality CSV refinement proposal.
-- Added a temporary v0.5.x cross-agent delegation CSV refinement proposal.
-- Added a temporary v0.5.x evidence schema and examples track proposal.
-- Added v0.5.x #161 principal context degradation consolidation checkpoint and linked it from status materials.
-- Updated v0.5.x status after the tamper-evident evidence selected contexts incorporation decision.
-- Added a temporary v0.5.x tamper-evident evidence selected contexts incorporation decision.
-- Updated v0.5.x status after reviewing `AAEF-EVD-01` evidence sufficiency coverage.
-- Added a temporary v0.5.x `AAEF-EVD-01` evidence sufficiency and limitation review proposal.
-- Updated v0.5.x status after the evidence depth and E5 profile decision proposal.
-- Added a temporary v0.5.x evidence depth and E5 profile decision proposal.
-- Updated v0.5.x status after incident-response evidence preservation guidance and candidate appendix completion.
-- Added a temporary v0.5.x incident-response evidence preservation candidate appendix.
-- Added a temporary v0.5.x incorporation decision register for #161 through #167.
+### v0.6.0 Planning and Adoption Readiness
 
-### Documentation
+- Added the v0.6.0 planning input synthesis for the Practical Adoption Readiness planning cycle.
+- Added initial five-pillar v0.6.0 planning drafts for Implementer Readiness, Operational Readiness, Legal and Compliance Applicability, Security Architecture Hardening, and Risk Owner / Executive Adoption.
+- Added the Operational Responsibility Matrix planning draft for operational ownership, readiness questions, evidence examples, and operating metrics.
+- Added the High-Impact Production Minimum Architecture Profile planning draft for minimum production architecture expectations, Trusted Control Boundary assumptions, backend verification, evidence, monitoring, and freeze considerations.
+- Added the Authorization Decision Artifact Minimal Profile planning draft for candidate decision fields, dispatch validation, backend relying-party verification, and evidence linkage.
+- Added the Implementer Quick Start planning draft for the minimal implementation path from action request through authorization, dispatch, backend verification, evidence, monitoring, and reconstruction.
+- Added the Legal and Compliance Applicability Note planning draft to define conservative claim boundaries, applicability positioning, evidence privacy and retention considerations, contractual topics, and SaaS / external-agent responsibility boundaries.
+- Added the Risk Owner Guide planning draft for decision inputs, decision outcomes, high-impact action decision matrix, residual risk tracking, exception management, KRIs/KPIs, and executive reporting considerations.
+- Added the v0.6.0 Planning Progress Summary to summarize the initial five-pillar planning set, cross-workstream integration, document-map review follow-up, and remaining planning candidates.
+
+### Repository Structure and Documentation
+
+- Registered previously missing top-level numbered English documents in `docs/en/document-map.md`, including core framework, assessment, schema reference, non-normative planning, example, and guidance documents.
+- Updated document-map coverage so all 63 top-level numbered English docs under `docs/en/` are represented.
+- Added and maintained status index entries for v0.6.0 planning documents.
 - Updated Japanese README document status to align with the v0.5.0 Public Review Planning Release.
-- Added non-normative evidence integrity profile guidance for high-impact and audit-grade v0.5.x follow-up work.
-- Added non-normative cross-agent budget propagation guidance for v0.5.x follow-up work.
-- Added non-normative cross-agent delegation negative test guidance for v0.5.x follow-up work.
-- Added non-normative capability-scoped cross-agent delegation guidance for v0.5.x follow-up work.
-- Added a temporary v0.5.x tamper-evident evidence selected contexts proposal.
 - Added a document map to classify AAEF documents by role without moving existing files.
-- Added non-normative tamper-evident evidence requirements guidance for selected v0.5.x contexts.
-- Added a temporary v0.5.x incident-response evidence preservation guidance proposal.
-- Added non-normative principal context degradation testing guidance for v0.5.x follow-up work.
-- Added a researcher overview as a research-facing entry point with reading paths, review questions, and links to open research questions and v0.5.x follow-up work.
+- Added a researcher overview as a research-facing entry point with reading paths, review questions, links to open research questions, and v0.5.x follow-up work.
+- Added non-normative v0.5.x follow-up guidance covering evidence integrity, cross-agent budget propagation, cross-agent delegation, capability-scoped delegation, tamper-evident evidence requirements, principal context degradation testing, approval quality testing, and evidence expectations.
 
-### Testing and Assessment
-- Added v0.5.x #163 delegation acceptance/refusal and chain accountability negative tests consolidation checkpoint and linked it from status materials.
-- Updated v0.5.x status documents after the approval quality testing procedure refinement.
-- Updated v0.5.x status documents after the cross-agent delegation testing procedure refinement.
-- Added a temporary v0.5.x testing incorporation readiness review for selected testing candidates.
-- Added a temporary v0.5.x testing candidate selection document for #161, #163, and #167.
-- Added non-normative approval quality testing and evidence guidance for v0.5.x follow-up work.
-- Added a temporary v0.5.x testing candidate mapping document for likely control areas and evidence expectations.
-- Added a temporary v0.5.x evidence integrity negative tests CSV refinement proposal.
-- Added a temporary v0.5.x evidence integrity negative tests candidate appendix.
-- Added a temporary v0.5.x evidence integrity negative tests track proposal.
-- Refined `AAEF-HUM-01` and `AAEF-AUZ-03` testing procedure language for approval quality and approval-to-execution binding.
-- Added a temporary v0.5.x approval quality testing candidate appendix.
-- Added a temporary v0.5.x approval quality testing proposal.
-- Added a temporary v0.5.x cross-agent delegation testing candidate appendix.
-- Added a temporary v0.5.x cross-agent delegation testing proposal.
-- Refined `AAEF-AUZ-02` and `AAEF-AUZ-07` testing procedure language for scope expansion and authority lifecycle state changes.
-- Added temporary v0.5.x testing draft pass/fail criteria for selected testing candidates.
-- Added a temporary v0.5.x testing procedure candidate matrix for selected testing candidates.
-- Refined `AAEF-DEL-01` and `AAEF-DEL-05` testing procedure language for cross-agent delegation authority validation.
-- Updated v0.5.x status documents after the principal context testing procedure refinement.
-- Added a temporary v0.5.x principal context testing CSV refinement proposal.
-- Added a temporary v0.5.x principal context testing candidate appendix.
-- Added a temporary v0.5.x principal context testing proposal for the first testing incorporation batch.
+### v0.5.x Follow-up Planning and Status
 
-### Schema and Examples
-- Added an approval-binding evidence example using optional approval source, approval binding, and enforcement fields.
-- Added an integrity-focused evidence example using optional evidence integrity and trust limitation fields.
+- Consolidated v0.5.x follow-up status for issues #161 through #167.
+- Added the v0.5.x follow-up completion summary after #161 through #167 were closed.
+- Added temporary v0.5.x issue consolidation checkpoints, incorporation reviews, decision registers, candidate appendices, and track proposals under `docs/en/status/`.
+- Recorded v0.5.x follow-up decisions and status updates for principal context degradation, cross-agent delegation, delegation acceptance/refusal, cross-agent budget propagation, evidence integrity, tamper-evident evidence contexts, and approval quality.
+
+### Testing, Assessment, Schema, and Examples
+
+- Refined testing procedure language for principal context degradation, cross-agent delegation, authority lifecycle state changes, approval quality, approval-to-execution binding, and evidence integrity scenarios.
+- Added temporary v0.5.x testing proposals, testing candidate appendices, testing candidate matrices, testing incorporation reviews, and testing refinement proposals.
 - Added optional Evidence Event Schema fields for evidence integrity, evidence trust limitations, approval evidence source, approval binding, and approval enforcement references.
-- Added a temporary v0.5.x evidence schema/example implementation readiness review.
-- Added a temporary v0.5.x evidence example design proposal.
-- Added a temporary v0.5.x evidence schema field proposal.
-- Updated v0.5.x status after the negative evidence examples and validator fixtures decision proposal.
-- Added a temporary v0.5.x negative evidence examples and validator fixtures decision proposal.
+- Added approval-binding and integrity-focused evidence examples.
+- Added temporary v0.5.x evidence schema, evidence example, negative evidence example, and validator fixture planning materials.
 
-### Tooling
+### Tooling and Validation
+
 - Added Markdown index validation for status document indexes and document-map rows.
+- Strengthened Markdown index validation so top-level numbered English docs under `docs/en/` must be represented in `docs/en/document-map.md`.
+- Added regression protection for repository review findings F-01 and F-05 related to document-map coverage.
 
 ## v0.5.0 Public Review Planning Release - 2026-04-29
 


### PR DESCRIPTION
## Summary

This PR cleans up the `CHANGELOG.md` Unreleased section after the initial v0.6.0 planning set and repository review follow-up work.

The previous Unreleased section primarily contained detailed v0.5.x follow-up status entries. This PR consolidates those entries and adds the v0.6.0 planning progress that has now been merged.

## Changes

- Reorganizes the Unreleased section into clearer semantic groups
- Adds v0.6.0 Planning and Adoption Readiness entries
- Consolidates v0.5.x follow-up planning and status entries
- Records repository structure and document-map coverage work
- Records tooling and validation updates for document-map coverage regression protection
- Keeps schema, examples, testing, and assessment updates grouped separately

## Scope

This PR is changelog-only.

It does not:

- change active controls
- change the current control and assessment baseline
- change schemas, CSV artifacts, examples, or mappings
- promote planning drafts into active requirements
- remove or archive status documents
- create a release tag

## Validation

The following validation passed:

    py tools/validate_markdown_indexes.py

## Related PRs

- #242
- #248
- #249
- #250
- #251
- #252
- #253
- #254
- #255
- #256

## Related review findings

Supports follow-up for:

- F-02: Unreleased CHANGELOG accumulation and release-boundary clarity

## Related issues

Related to #241.
