### PR TITLE
Add v0.6.0 status document inventory planning draft

### DIFF
--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -182,6 +182,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v060-risk-owner-guide-planning.md` | v0.6.0 risk owner guide planning draft | Defines candidate risk owner decision inputs, outcomes, decision matrix, risk acceptance structure, residual risk register fields, KRIs/KPIs, exception handling, and executive reporting considerations. |
 | `docs/en/status/v060-planning-progress-summary.md` | v0.6.0 planning progress summary | Summarizes the initial five-pillar v0.6.0 planning set, document-map review follow-up, and remaining planning follow-up candidates. |
 | `docs/en/status/v060-status-document-triage-planning.md` | v0.6.0 status document triage planning draft | Defines candidate keep, archive, promote, replace, and remove outcomes for accumulated status documents without moving or deleting files. |
+| `docs/en/status/v060-status-document-inventory-planning.md` | v0.6.0 status document inventory planning draft | Provides an initial generated inventory of status documents with candidate triage categories and outcomes without moving or deleting files. |
 
 ## Numbered Document Coverage Additions
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -93,3 +93,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - [`docs/en/status/v060-risk-owner-guide-planning.md`](v060-risk-owner-guide-planning.md) — v0.6.0 risk owner guide planning draft.
 - [`docs/en/status/v060-planning-progress-summary.md`](v060-planning-progress-summary.md) — v0.6.0 planning progress summary.
 - [`docs/en/status/v060-status-document-triage-planning.md`](v060-status-document-triage-planning.md) — v0.6.0 status document triage planning draft.
+- [`docs/en/status/v060-status-document-inventory-planning.md`](v060-status-document-inventory-planning.md) — v0.6.0 status document inventory planning draft.

--- a/docs/en/status/v060-status-document-inventory-planning.md
+++ b/docs/en/status/v060-status-document-inventory-planning.md
@@ -1,0 +1,159 @@
+# AAEF v0.6.0 Status Document Inventory Planning Draft
+
+Status: Planning input  
+Related roadmap: #241  
+Milestone: v0.6.0 Planning  
+Related triage planning: `docs/en/status/v060-status-document-triage-planning.md`  
+Planned release theme: AAEF v0.6.0 Practical Adoption Readiness
+
+## Purpose
+
+This document provides an initial inventory of `docs/en/status/` documents for future keep, archive, promote, replace, or remove triage.
+
+This inventory is planning material. It does not delete, move, archive, promote, or replace any document by itself.
+
+## Scope
+
+This inventory covers top-level Markdown files under:
+
+- `docs/en/status/`
+
+It does not cover:
+
+- top-level numbered framework documents under `docs/en/`
+- release checklists
+- schemas
+- examples
+- mappings
+- CSV artifacts
+- README files outside `docs/en/status/`
+
+## Inventory method
+
+This inventory was generated from repository file names and document headings.
+
+The recommended outcomes are candidate classifications only. They require manual review before any file movement, archival, promotion, replacement, or removal.
+
+## Candidate outcome summary
+
+| Candidate outcome | Count |
+| --- | --- |
+| archive candidate | 36 |
+| keep | 15 |
+| replace candidate | 1 |
+
+## Status document inventory
+
+| Document | Title | Candidate category | Candidate outcome | Related reference | Rationale |
+| --- | --- | --- | --- | --- | --- |
+| `docs/en/status/README.md` | Status Documents | status index | keep |  | Status directory index and entry point. |
+| `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` | v0.5.x Approval Quality Testing CSV Refinement Proposal | temporary proposal | archive candidate | #167 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` | v0.5.x Approval Quality Testing Candidate Appendix | candidate appendix or matrix | archive candidate | #167 | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v050x-approval-quality-testing-proposal.md` | v0.5.x Approval Quality Testing Proposal | temporary proposal | archive candidate | #167 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` | v0.5.x Cross-Agent Delegation Testing CSV Refinement Proposal | temporary proposal | archive candidate | #162/#163 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md` | v0.5.x Cross-Agent Delegation Testing Candidate Appendix | candidate appendix or matrix | archive candidate | #162/#163 | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v050x-cross-agent-delegation-testing-proposal.md` | v0.5.x Cross-Agent Delegation Testing Proposal | temporary proposal | archive candidate | #162/#163 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` | v0.5.x AAEF-EVD-01 Evidence Sufficiency and Limitation Review Proposal | temporary proposal | archive candidate |  | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` | v0.5.x Evidence Depth and E5 Profile Decision Proposal | incorporation decision record | keep |  | Decision rationale may be useful for traceability. |
+| `docs/en/status/v050x-evidence-example-design-proposal.md` | v0.5.x Evidence Example Design Proposal | temporary proposal | archive candidate |  | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md` | v0.5.x Evidence Integrity CSV Refinement Proposal | temporary proposal | archive candidate | #165 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` | v0.5.x Evidence Integrity Negative Tests Candidate Appendix | candidate appendix or matrix | archive candidate | #165 | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md` | v0.5.x Evidence Integrity Negative Tests CSV Refinement Proposal | temporary proposal | archive candidate | #165 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` | v0.5.x Evidence Integrity Negative Tests Track Proposal | temporary proposal | archive candidate | #165 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-evidence-schema-and-examples-track-proposal.md` | v0.5.x Evidence Schema and Examples Track Proposal | temporary proposal | archive candidate |  | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md` | v0.5.x Evidence Schema and Example Implementation Readiness Review | v0.5.x status material | archive candidate |  | v0.5.x status material should be checked against the completion summary before archiving. |
+| `docs/en/status/v050x-evidence-schema-field-proposal.md` | v0.5.x Evidence Schema Field Proposal | temporary proposal | archive candidate |  | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-follow-up-completion-summary.md` | v0.5.x Follow-up Completion Summary | v0.5.x completion record | keep |  | Completion summary preserves cycle-level closure context. |
+| `docs/en/status/v050x-follow-up-status.md` | v0.5.x Follow-up Status | v0.5.x status material | archive candidate |  | v0.5.x status material should be checked against the completion summary before archiving. |
+| `docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md` | v0.5.x Incident-Response Evidence Preservation Candidate Appendix | candidate appendix or matrix | archive candidate |  | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v050x-incident-response-evidence-preservation-guidance-proposal.md` | v0.5.x Incident-Response Evidence Preservation Guidance Proposal | temporary proposal | archive candidate |  | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-incorporation-decision-register.md` | v0.5.x Incorporation Decision Register | incorporation decision record | keep |  | Decision rationale may be useful for traceability. |
+| `docs/en/status/v050x-incorporation-review-checkpoint.md` | v0.5.x Incorporation Review Checkpoint | temporary review checkpoint | archive candidate |  | Review checkpoint may be historical after incorporation or completion. |
+| `docs/en/status/v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md` | v0.5.x Issue #161 Principal Context Degradation Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | #161 | Issue-specific checkpoint appears historical after related issue closure. |
+| `docs/en/status/v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md` | v0.5.x Issue #162 Cross-Agent Capability-Scoped Delegation Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | #162 | Issue-specific checkpoint appears historical after related issue closure. |
+| `docs/en/status/v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md` | v0.5.x Issue #163 Delegation Negative Tests Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | #163 | Issue-specific checkpoint appears historical after related issue closure. |
+| `docs/en/status/v050x-issue-164-budget-propagation-consolidation-checkpoint.md` | v0.5.x Issue #164 Budget Propagation Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | #164 | Issue-specific checkpoint appears historical after related issue closure. |
+| `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md` | v0.5.x Issue #165 Evidence Integrity Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | #165 | Issue-specific checkpoint appears historical after related issue closure. |
+| `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md` | v0.5.x Issue #166 Tamper-Evident Evidence Contexts Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | #166 | Issue-specific checkpoint appears historical after related issue closure. |
+| `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md` | v0.5.x Issue #167 Approval Quality Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | #167 | Issue-specific checkpoint appears historical after related issue closure. |
+| `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md` | v0.5.x Negative Evidence Examples and Validator Fixtures Decision Proposal | incorporation decision record | keep |  | Decision rationale may be useful for traceability. |
+| `docs/en/status/v050x-next-phase-track-plan.md` | v0.5.x Next Phase Track Plan | temporary planning tracker | replace candidate |  | Tracking material may be superseded by v0.5.x completion summary or v0.6.0 progress summary. |
+| `docs/en/status/v050x-principal-context-testing-candidate-appendix.md` | v0.5.x Principal Context Testing Candidate Appendix | candidate appendix or matrix | archive candidate | #161 | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md` | v0.5.x Principal Context Testing CSV Refinement Proposal | temporary proposal | archive candidate | #161 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-principal-context-testing-proposal.md` | v0.5.x Principal Context Testing Proposal | temporary proposal | archive candidate | #161 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Candidate Appendix | candidate appendix or matrix | archive candidate | #166 | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Incorporation Decision | incorporation decision record | keep | #166 | Decision rationale may be useful for traceability. |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Proposal | temporary proposal | archive candidate | #166 | Proposal material likely served a completed workstream and should be checked for incorporation. |
+| `docs/en/status/v050x-testing-candidate-mapping.md` | v0.5.x Testing Candidate Mapping | v0.5.x status material | archive candidate |  | v0.5.x status material should be checked against the completion summary before archiving. |
+| `docs/en/status/v050x-testing-candidate-selection.md` | v0.5.x Testing Candidate Selection | candidate appendix or matrix | archive candidate |  | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v050x-testing-draft-pass-fail-criteria.md` | v0.5.x Testing Draft Pass/Fail Criteria | v0.5.x status material | archive candidate |  | v0.5.x status material should be checked against the completion summary before archiving. |
+| `docs/en/status/v050x-testing-incorporation-readiness-review.md` | v0.5.x Testing Incorporation Readiness Review | temporary review checkpoint | archive candidate |  | Review checkpoint may be historical after incorporation or completion. |
+| `docs/en/status/v050x-testing-procedure-candidate-matrix.md` | v0.5.x Testing Procedure Candidate Matrix | candidate appendix or matrix | archive candidate |  | Candidate material may be superseded by incorporated guidance, testing procedures, or summaries. |
+| `docs/en/status/v060-authorization-decision-artifact-minimal-profile-planning.md` | AAEF v0.6.0 Authorization Decision Artifact Minimal Profile Planning Draft | current v0.6.0 planning foundation | keep |  | Current v0.6.0 adoption-readiness planning draft. |
+| `docs/en/status/v060-high-impact-production-minimum-architecture-profile-planning.md` | AAEF v0.6.0 High-Impact Production Minimum Architecture Profile Planning Draft | current v0.6.0 planning foundation | keep |  | Current v0.6.0 adoption-readiness planning draft. |
+| `docs/en/status/v060-implementer-quick-start-planning.md` | AAEF v0.6.0 Implementer Quick Start Planning Draft | current v0.6.0 planning foundation | keep |  | Current v0.6.0 adoption-readiness planning draft. |
+| `docs/en/status/v060-legal-compliance-applicability-note-planning.md` | AAEF v0.6.0 Legal and Compliance Applicability Note Planning Draft | current v0.6.0 planning foundation | keep |  | Current v0.6.0 adoption-readiness planning draft. |
+| `docs/en/status/v060-operational-responsibility-matrix-planning.md` | AAEF v0.6.0 Operational Responsibility Matrix Planning Draft | current v0.6.0 planning foundation | keep |  | Current v0.6.0 adoption-readiness planning draft. |
+| `docs/en/status/v060-planning-input-synthesis.md` | AAEF v0.6.0 Planning Input Synthesis | current v0.6.0 planning foundation | keep |  | Current v0.6.0 planning basis and workstream synthesis. |
+| `docs/en/status/v060-planning-progress-summary.md` | AAEF v0.6.0 Planning Progress Summary | current v0.6.0 progress summary | keep |  | Current v0.6.0 planning progress summary. |
+| `docs/en/status/v060-risk-owner-guide-planning.md` | AAEF v0.6.0 Risk Owner Guide Planning Draft | current v0.6.0 planning foundation | keep |  | Current v0.6.0 adoption-readiness planning draft. |
+| `docs/en/status/v060-status-document-triage-planning.md` | AAEF v0.6.0 Status Document Triage Planning Draft | current v0.6.0 triage planning | keep |  | Current v0.6.0 status triage planning material. |
+
+## Interpretation guidance
+
+Candidate outcomes should be interpreted conservatively.
+
+- `keep` means the document appears useful in its current location.
+- `archive candidate` means the document may be historical, but should not be moved until references and incorporation status are reviewed.
+- `promote candidate` means the document may later become an adoption-facing artifact through a separate PR.
+- `replace candidate` means the document may be superseded by a newer summary or decision record.
+- `review required` means the document needs manual review before classification.
+
+## Recommended next review questions
+
+For each document, reviewers should ask:
+
+1. Is this document still part of current planning?
+2. Has the content been incorporated into another document, CSV, schema, example, or summary?
+3. Does the document preserve unique rationale or decision history?
+4. Is the document referenced by issues, PRs, `docs/en/status/README.md`, `docs/en/document-map.md`, or `CHANGELOG.md`?
+5. Would moving or archiving it reduce traceability?
+6. Should it become adoption-facing guidance?
+7. Should it remain explicitly non-normative?
+8. Should it receive a supersession note?
+
+## Recommended next step
+
+The next step should be a manual triage pass that converts this generated inventory into a reviewed triage decision register.
+
+That follow-up should decide whether to:
+
+- keep documents in place
+- add historical headers
+- create an archive path
+- promote selected planning drafts
+- replace older temporary trackers with newer summaries
+- defer movement until v0.6.0 release preparation
+
+## Non-goals
+
+This inventory does not:
+
+- remove files
+- move files
+- archive files
+- promote status material into active guidance
+- change active controls
+- change the current control and assessment baseline
+- change schemas, CSV artifacts, examples, or mappings
+
+## Acceptance criteria for this inventory
+
+This inventory is sufficient when:
+
+- `docs/en/status/` documents are listed
+- candidate categories are assigned
+- candidate outcomes are assigned
+- no file movement is performed
+- no active baseline change is implied
+- roadmap issue #241 can use the inventory as input for a future reviewed triage decision register


### PR DESCRIPTION
## Summary

This PR adds the v0.6.0 Status Document Inventory planning draft.

The draft provides an initial generated inventory of `docs/en/status/` documents with candidate triage categories and candidate outcomes.

## Changes

- Adds `docs/en/status/v060-status-document-inventory-planning.md`
- Registers the new status document in `docs/en/status/README.md`
- Registers the new status document in `docs/en/document-map.md`

## Scope

This PR is planning/inventory only.

It does not:

- delete status documents
- archive status documents
- move status documents
- promote status documents into active or adoption-facing guidance
- change active controls
- change the current control and assessment baseline
- change schemas, CSV artifacts, examples, or mappings

## Inventory focus

The new draft records:

- generated inventory of `docs/en/status/*.md`
- candidate categories
- candidate keep / archive / promote / replace / remove outcomes
- candidate outcome summary
- interpretation guidance
- recommended next review questions
- recommended next step toward a reviewed triage decision register

## Validation

The following validation should pass:

    py tools/validate_markdown_indexes.py

## Related review finding

Supports follow-up for:

- F-04: accumulated temporary status documents require keep / archive / promote triage

## Related PRs

Follow-up to #258.

## Related issues

Related to #241.
