### PR TITLE
Add v0.6.0 status document triage decision register

### DIFF
--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -183,6 +183,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v060-planning-progress-summary.md` | v0.6.0 planning progress summary | Summarizes the initial five-pillar v0.6.0 planning set, document-map review follow-up, and remaining planning follow-up candidates. |
 | `docs/en/status/v060-status-document-triage-planning.md` | v0.6.0 status document triage planning draft | Defines candidate keep, archive, promote, replace, and remove outcomes for accumulated status documents without moving or deleting files. |
 | `docs/en/status/v060-status-document-inventory-planning.md` | v0.6.0 status document inventory planning draft | Provides an initial generated inventory of status documents with candidate triage categories and outcomes without moving or deleting files. |
+| `docs/en/status/v060-status-document-triage-decision-register.md` | v0.6.0 status document triage decision register | Converts the generated status document inventory into conservative candidate decisions without moving, deleting, archiving, or promoting files. |
 
 ## Numbered Document Coverage Additions
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -94,3 +94,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - [`docs/en/status/v060-planning-progress-summary.md`](v060-planning-progress-summary.md) — v0.6.0 planning progress summary.
 - [`docs/en/status/v060-status-document-triage-planning.md`](v060-status-document-triage-planning.md) — v0.6.0 status document triage planning draft.
 - [`docs/en/status/v060-status-document-inventory-planning.md`](v060-status-document-inventory-planning.md) — v0.6.0 status document inventory planning draft.
+- [`docs/en/status/v060-status-document-triage-decision-register.md`](v060-status-document-triage-decision-register.md) — v0.6.0 status document triage decision register.

--- a/docs/en/status/v060-status-document-triage-decision-register.md
+++ b/docs/en/status/v060-status-document-triage-decision-register.md
@@ -1,0 +1,153 @@
+# AAEF v0.6.0 Status Document Triage Decision Register
+
+Status: Planning decision register  
+Related roadmap: #241  
+Milestone: v0.6.0 Planning  
+Related triage planning: `docs/en/status/v060-status-document-triage-planning.md`  
+Related inventory: `docs/en/status/v060-status-document-inventory-planning.md`  
+Planned release theme: AAEF v0.6.0 Practical Adoption Readiness
+
+## Purpose
+
+This document converts the generated status document inventory into an initial triage decision register.
+
+The purpose is to record candidate reviewed decisions for accumulated `docs/en/status/` documents before any future archive, replacement, promotion, or removal work.
+
+This document is still planning material. It does not move, delete, archive, promote, replace, or supersede any document by itself.
+
+## Source inventory
+
+This register is based on:
+
+- `docs/en/status/v060-status-document-triage-planning.md`
+- `docs/en/status/v060-status-document-inventory-planning.md`
+
+The inventory counted 52 status documents and assigned initial candidate outcomes.
+
+## Decision summary
+
+| Candidate decision | Count |
+| --- | --- |
+| archive later | 36 |
+| keep | 15 |
+| replace later | 1 |
+
+## Decision policy used in this register
+
+The first decision pass is intentionally conservative.
+
+- Current v0.6.0 planning documents are kept.
+- Status README is kept.
+- Completion summaries are kept.
+- Incorporation decision records and decision registers are kept.
+- Temporary proposals, candidate appendices, and issue-specific checkpoints are marked as `archive later`, not archived immediately.
+- Tracking material that is likely superseded is marked as `replace later`, not replaced immediately.
+- No document is removed in this decision register.
+- No document is promoted in this decision register.
+
+## Status document triage decision register
+
+| Document | Title | Inventory category | Inventory outcome | Candidate decision | Related reference | Decision rationale | Next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `docs/en/status/README.md` | Status Documents | status index | keep | keep |  | Status README remains the status directory index. | none |
+| `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` | v0.5.x Approval Quality Testing CSV Refinement Proposal | temporary proposal | archive candidate | archive later | #167 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` | v0.5.x Approval Quality Testing Candidate Appendix | candidate appendix or matrix | archive candidate | archive later | #167 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-approval-quality-testing-proposal.md` | v0.5.x Approval Quality Testing Proposal | temporary proposal | archive candidate | archive later | #167 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` | v0.5.x Cross-Agent Delegation Testing CSV Refinement Proposal | temporary proposal | archive candidate | archive later | #162/#163 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md` | v0.5.x Cross-Agent Delegation Testing Candidate Appendix | candidate appendix or matrix | archive candidate | archive later | #162/#163 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-cross-agent-delegation-testing-proposal.md` | v0.5.x Cross-Agent Delegation Testing Proposal | temporary proposal | archive candidate | archive later | #162/#163 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` | v0.5.x AAEF-EVD-01 Evidence Sufficiency and Limitation Review Proposal | temporary proposal | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` | v0.5.x Evidence Depth and E5 Profile Decision Proposal | incorporation decision record | keep | keep |  | Retain because decision rationale is useful for historical traceability. | consider historical header later |
+| `docs/en/status/v050x-evidence-example-design-proposal.md` | v0.5.x Evidence Example Design Proposal | temporary proposal | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md` | v0.5.x Evidence Integrity CSV Refinement Proposal | temporary proposal | archive candidate | archive later | #165 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` | v0.5.x Evidence Integrity Negative Tests Candidate Appendix | candidate appendix or matrix | archive candidate | archive later | #165 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md` | v0.5.x Evidence Integrity Negative Tests CSV Refinement Proposal | temporary proposal | archive candidate | archive later | #165 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` | v0.5.x Evidence Integrity Negative Tests Track Proposal | temporary proposal | archive candidate | archive later | #165 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-schema-and-examples-track-proposal.md` | v0.5.x Evidence Schema and Examples Track Proposal | temporary proposal | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md` | v0.5.x Evidence Schema and Example Implementation Readiness Review | v0.5.x status material | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-evidence-schema-field-proposal.md` | v0.5.x Evidence Schema Field Proposal | temporary proposal | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-follow-up-completion-summary.md` | v0.5.x Follow-up Completion Summary | v0.5.x completion record | keep | keep |  | Retain as v0.5.x cycle-level completion record. | consider historical header later |
+| `docs/en/status/v050x-follow-up-status.md` | v0.5.x Follow-up Status | v0.5.x status material | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md` | v0.5.x Incident-Response Evidence Preservation Candidate Appendix | candidate appendix or matrix | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-incident-response-evidence-preservation-guidance-proposal.md` | v0.5.x Incident-Response Evidence Preservation Guidance Proposal | temporary proposal | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-incorporation-decision-register.md` | v0.5.x Incorporation Decision Register | incorporation decision record | keep | keep |  | Retain because decision rationale is useful for historical traceability. | consider historical header later |
+| `docs/en/status/v050x-incorporation-review-checkpoint.md` | v0.5.x Incorporation Review Checkpoint | temporary review checkpoint | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md` | v0.5.x Issue #161 Principal Context Degradation Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | archive later | #161 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md` | v0.5.x Issue #162 Cross-Agent Capability-Scoped Delegation Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | archive later | #162 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md` | v0.5.x Issue #163 Delegation Negative Tests Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | archive later | #163 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-issue-164-budget-propagation-consolidation-checkpoint.md` | v0.5.x Issue #164 Budget Propagation Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | archive later | #164 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md` | v0.5.x Issue #165 Evidence Integrity Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | archive later | #165 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md` | v0.5.x Issue #166 Tamper-Evident Evidence Contexts Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | archive later | #166 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md` | v0.5.x Issue #167 Approval Quality Consolidation Checkpoint | issue consolidation checkpoint | archive candidate | archive later | #167 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-negative-evidence-examples-fixtures-decision-proposal.md` | v0.5.x Negative Evidence Examples and Validator Fixtures Decision Proposal | incorporation decision record | keep | keep |  | Retain because decision rationale is useful for historical traceability. | consider historical header later |
+| `docs/en/status/v050x-next-phase-track-plan.md` | v0.5.x Next Phase Track Plan | temporary planning tracker | replace candidate | replace later |  | Likely superseded by newer completion or progress summaries; do not move until references are checked. | identify superseding document and add supersession note |
+| `docs/en/status/v050x-principal-context-testing-candidate-appendix.md` | v0.5.x Principal Context Testing Candidate Appendix | candidate appendix or matrix | archive candidate | archive later | #161 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md` | v0.5.x Principal Context Testing CSV Refinement Proposal | temporary proposal | archive candidate | archive later | #161 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-principal-context-testing-proposal.md` | v0.5.x Principal Context Testing Proposal | temporary proposal | archive candidate | archive later | #161 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Candidate Appendix | candidate appendix or matrix | archive candidate | archive later | #166 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Incorporation Decision | incorporation decision record | keep | keep | #166 | Retain because decision rationale is useful for historical traceability. | consider historical header later |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Proposal | temporary proposal | archive candidate | archive later | #166 | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-testing-candidate-mapping.md` | v0.5.x Testing Candidate Mapping | v0.5.x status material | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-testing-candidate-selection.md` | v0.5.x Testing Candidate Selection | candidate appendix or matrix | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-testing-draft-pass-fail-criteria.md` | v0.5.x Testing Draft Pass/Fail Criteria | v0.5.x status material | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-testing-incorporation-readiness-review.md` | v0.5.x Testing Incorporation Readiness Review | temporary review checkpoint | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v050x-testing-procedure-candidate-matrix.md` | v0.5.x Testing Procedure Candidate Matrix | candidate appendix or matrix | archive candidate | archive later |  | Likely historical or temporary planning material; preserve traceability before movement. | check references and incorporation status before archive |
+| `docs/en/status/v060-authorization-decision-artifact-minimal-profile-planning.md` | AAEF v0.6.0 Authorization Decision Artifact Minimal Profile Planning Draft | current v0.6.0 planning foundation | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-high-impact-production-minimum-architecture-profile-planning.md` | AAEF v0.6.0 High-Impact Production Minimum Architecture Profile Planning Draft | current v0.6.0 planning foundation | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-implementer-quick-start-planning.md` | AAEF v0.6.0 Implementer Quick Start Planning Draft | current v0.6.0 planning foundation | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-legal-compliance-applicability-note-planning.md` | AAEF v0.6.0 Legal and Compliance Applicability Note Planning Draft | current v0.6.0 planning foundation | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-operational-responsibility-matrix-planning.md` | AAEF v0.6.0 Operational Responsibility Matrix Planning Draft | current v0.6.0 planning foundation | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-planning-input-synthesis.md` | AAEF v0.6.0 Planning Input Synthesis | current v0.6.0 planning foundation | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-planning-progress-summary.md` | AAEF v0.6.0 Planning Progress Summary | current v0.6.0 progress summary | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-risk-owner-guide-planning.md` | AAEF v0.6.0 Risk Owner Guide Planning Draft | current v0.6.0 planning foundation | keep | keep |  | Retain as current v0.6.0 Practical Adoption Readiness planning material. | consider promotion in a separate adoption-facing PR |
+| `docs/en/status/v060-status-document-triage-planning.md` | AAEF v0.6.0 Status Document Triage Planning Draft | current v0.6.0 triage planning | keep | keep |  | Retain as current triage planning context. | review after triage execution |
+
+## Interpretation
+
+The candidate decisions mean:
+
+| Decision | Meaning |
+| --- | --- |
+| `keep` | Keep in place for now. |
+| `archive later` | Consider archiving in a future PR after references and incorporation status are checked. |
+| `replace later` | Consider supersession or replacement in a future PR after confirming the newer authoritative summary. |
+| `manual review required` | Review manually before any action. |
+
+## Recommended next actions
+
+Recommended follow-up actions:
+
+1. Check references for all `archive later` documents in:
+   - `docs/en/status/README.md`
+   - `docs/en/document-map.md`
+   - `CHANGELOG.md`
+   - open and recently closed GitHub issues
+2. Decide whether to create an archive path.
+3. Add historical or supersession headers before moving files.
+4. Keep current v0.6.0 planning drafts in place until adoption-facing promotion decisions are made.
+5. Promote selected v0.6.0 planning drafts only through explicit adoption-facing PRs.
+6. Avoid deletion unless a later manual review confirms that the document is duplicated, obsolete, and no longer useful for traceability.
+
+## Non-goals
+
+This decision register does not:
+
+- delete files
+- move files
+- archive files
+- promote status material into active guidance
+- change active controls
+- change the current control and assessment baseline
+- change schemas, CSV artifacts, examples, or mappings
+- close roadmap issue #241
+- close umbrella issue #3
+
+## Acceptance criteria for this decision register
+
+This decision register is sufficient when:
+
+- inventory rows are converted into candidate decisions
+- conservative decisions are recorded
+- no file movement is performed
+- no active baseline change is implied
+- roadmap issue #241 can use this document as input for a future archive, replacement, or promotion PR


### PR DESCRIPTION
## Summary

This PR adds the v0.6.0 Status Document Triage Decision Register.

The register converts the generated status document inventory into conservative candidate decisions before any future archive, replacement, promotion, or removal work.

## Changes

- Adds `docs/en/status/v060-status-document-triage-decision-register.md`
- Registers the new status document in `docs/en/status/README.md`
- Registers the new status document in `docs/en/document-map.md`

## Scope

This PR is planning/decision-register only.

It does not:

- delete status documents
- archive status documents
- move status documents
- promote status documents into active or adoption-facing guidance
- replace status documents
- change active controls
- change the current control and assessment baseline
- change schemas, CSV artifacts, examples, or mappings

## Decision-register focus

The new draft records:

- source inventory references
- conservative decision policy
- decision summary
- converted candidate decisions for status documents
- recommended next actions before archival, replacement, or promotion
- non-goals and acceptance criteria

## Validation

The following validation should pass:

    py tools/validate_markdown_indexes.py

## Related review finding

Supports follow-up for:

- F-04: accumulated temporary status documents require keep / archive / promote triage

## Related PRs

Follow-up to #258 and #259.

## Related issues

Related to #241.
