### PR TITLE
Add v0.6.0 status document archive readiness review

### DIFF
--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -184,6 +184,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v060-status-document-triage-planning.md` | v0.6.0 status document triage planning draft | Defines candidate keep, archive, promote, replace, and remove outcomes for accumulated status documents without moving or deleting files. |
 | `docs/en/status/v060-status-document-inventory-planning.md` | v0.6.0 status document inventory planning draft | Provides an initial generated inventory of status documents with candidate triage categories and outcomes without moving or deleting files. |
 | `docs/en/status/v060-status-document-triage-decision-register.md` | v0.6.0 status document triage decision register | Converts the generated status document inventory into conservative candidate decisions without moving, deleting, archiving, or promoting files. |
+| `docs/en/status/v060-status-document-archive-readiness-review.md` | v0.6.0 status document archive readiness review | Reviews references for archive-later status documents before any future archive, movement, replacement, or deletion work. |
 
 ## Numbered Document Coverage Additions
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -95,3 +95,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - [`docs/en/status/v060-status-document-triage-planning.md`](v060-status-document-triage-planning.md) — v0.6.0 status document triage planning draft.
 - [`docs/en/status/v060-status-document-inventory-planning.md`](v060-status-document-inventory-planning.md) — v0.6.0 status document inventory planning draft.
 - [`docs/en/status/v060-status-document-triage-decision-register.md`](v060-status-document-triage-decision-register.md) — v0.6.0 status document triage decision register.
+- [`docs/en/status/v060-status-document-archive-readiness-review.md`](v060-status-document-archive-readiness-review.md) — v0.6.0 status document archive readiness review.

--- a/docs/en/status/v060-status-document-archive-readiness-review.md
+++ b/docs/en/status/v060-status-document-archive-readiness-review.md
@@ -1,0 +1,141 @@
+# AAEF v0.6.0 Status Document Archive Readiness Review
+
+Status: Planning review  
+Related roadmap: #241  
+Milestone: v0.6.0 Planning  
+Related triage planning: `docs/en/status/v060-status-document-triage-planning.md`  
+Related inventory: `docs/en/status/v060-status-document-inventory-planning.md`  
+Related decision register: `docs/en/status/v060-status-document-triage-decision-register.md`  
+Planned release theme: AAEF v0.6.0 Practical Adoption Readiness
+
+## Purpose
+
+This document reviews archive readiness for status documents marked `archive later` in the v0.6.0 Status Document Triage Decision Register.
+
+The purpose is to prepare for a future archive or historical-header PR without moving, deleting, archiving, replacing, or promoting any file in this PR.
+
+## Source decision register
+
+This review is based on:
+
+- `docs/en/status/v060-status-document-triage-decision-register.md`
+
+The decision register marked 36 documents as `archive later`.
+
+## Method
+
+This review performs a repository text reference scan for each `archive later` document.
+
+The scan looks for:
+
+- full status document paths
+- relative filename references
+- bare filename references
+- stem references
+
+References are grouped as:
+
+| Reference group | Meaning |
+| --- | --- |
+| Index references | References from `docs/en/status/README.md` or `docs/en/document-map.md`. |
+| CHANGELOG references | References from `CHANGELOG.md`. |
+| Status references | References from other `docs/en/status/` documents. |
+| Other references | References from outside status indexes, document map, changelog, and status documents. |
+
+This scan is a preparation aid, not a final proof that moving a file is safe.
+
+## Archive readiness summary
+
+| Metric | Count |
+| --- | --- |
+| Archive-later documents reviewed | 36 |
+| No non-index references detected | 0 |
+| Non-index references detected | 36 |
+| CHANGELOG references detected | 0 |
+| Other status document references detected | 36 |
+
+## Archive readiness review table
+
+| Document | Title | Related reference | Index references | CHANGELOG references | Other status references | Other references | Archive readiness | Recommended next step |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` | v0.5.x Approval Quality Testing CSV Refinement Proposal | #167 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` | v0.5.x Approval Quality Testing Candidate Appendix | #167 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-approval-quality-testing-proposal.md` | v0.5.x Approval Quality Testing Proposal | #167 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` | v0.5.x Cross-Agent Delegation Testing CSV Refinement Proposal | #162/#163 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md` | v0.5.x Cross-Agent Delegation Testing Candidate Appendix | #162/#163 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-cross-agent-delegation-testing-proposal.md` | v0.5.x Cross-Agent Delegation Testing Proposal | #162/#163 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` | v0.5.x AAEF-EVD-01 Evidence Sufficiency and Limitation Review Proposal | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v050x-incorporation-decision-register.md` (3)<br>`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` (3)<br>`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md` (3)<br>+2 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-example-design-proposal.md` | v0.5.x Evidence Example Design Proposal | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` (3)<br>`docs/en/status/v050x-evidence-schema-example-implementation-readiness.md` (6)<br>+4 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-integrity-csv-refinement-proposal.md` | v0.5.x Evidence Integrity CSV Refinement Proposal | #165 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` | v0.5.x Evidence Integrity Negative Tests Candidate Appendix | #165 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` (5)<br>`docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md` (3)<br>+4 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md` | v0.5.x Evidence Integrity Negative Tests CSV Refinement Proposal | #165 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` (5)<br>`docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md` (3)<br>`docs/en/status/v050x-incident-response-evidence-preservation-guidance-proposal.md` (3)<br>+3 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` | v0.5.x Evidence Integrity Negative Tests Track Proposal | #165 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` (3)<br>`docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md` (3)<br>+6 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-schema-and-examples-track-proposal.md` | v0.5.x Evidence Schema and Examples Track Proposal | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-evidence-example-design-proposal.md` (3)<br>`docs/en/status/v050x-evidence-schema-example-implementation-readiness.md` (3)<br>`docs/en/status/v050x-evidence-schema-field-proposal.md` (3)<br>+3 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-schema-example-implementation-readiness.md` | v0.5.x Evidence Schema and Example Implementation Readiness Review | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-evidence-example-design-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` (3)<br>+3 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-evidence-schema-field-proposal.md` | v0.5.x Evidence Schema Field Proposal | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-evidence-example-design-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-candidate-appendix.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` (3)<br>+5 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-follow-up-status.md` | v0.5.x Follow-up Status | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` (3)<br>`docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-csv-refinement-proposal.md` (3)<br>`docs/en/status/v050x-evidence-integrity-negative-tests-track-proposal.md` (3)<br>+11 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md` | v0.5.x Incident-Response Evidence Preservation Candidate Appendix | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` (3)<br>`docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-follow-up-status.md` (6)<br>`docs/en/status/v050x-incident-response-evidence-preservation-guidance-proposal.md` (8)<br>+7 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-incident-response-evidence-preservation-guidance-proposal.md` | v0.5.x Incident-Response Evidence Preservation Guidance Proposal | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evd01-evidence-sufficiency-limitation-review-proposal.md` (3)<br>`docs/en/status/v050x-evidence-depth-e5-profile-decision-proposal.md` (3)<br>`docs/en/status/v050x-follow-up-status.md` (6)<br>`docs/en/status/v050x-incident-response-evidence-preservation-candidate-appendix.md` (3)<br>+6 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-incorporation-review-checkpoint.md` | v0.5.x Incorporation Review Checkpoint | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-evidence-schema-and-examples-track-proposal.md` (3)<br>`docs/en/status/v050x-evidence-schema-field-proposal.md` (3)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v050x-incorporation-decision-register.md` (3)<br>+3 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-issue-161-principal-context-degradation-consolidation-checkpoint.md` | v0.5.x Issue #161 Principal Context Degradation Consolidation Checkpoint | #161 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-completion-summary.md` (2)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-issue-162-cross-agent-capability-delegation-consolidation-checkpoint.md` | v0.5.x Issue #162 Cross-Agent Capability-Scoped Delegation Consolidation Checkpoint | #162 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-completion-summary.md` (2)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-issue-163-delegation-negative-tests-consolidation-checkpoint.md` | v0.5.x Issue #163 Delegation Negative Tests Consolidation Checkpoint | #163 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-completion-summary.md` (2)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-issue-164-budget-propagation-consolidation-checkpoint.md` | v0.5.x Issue #164 Budget Propagation Consolidation Checkpoint | #164 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-completion-summary.md` (2)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-issue-165-evidence-integrity-consolidation-checkpoint.md` | v0.5.x Issue #165 Evidence Integrity Consolidation Checkpoint | #165 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-completion-summary.md` (2)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v050x-incorporation-decision-register.md` (3)<br>`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` (3)<br>+4 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-issue-166-tamper-evident-contexts-consolidation-checkpoint.md` | v0.5.x Issue #166 Tamper-Evident Evidence Contexts Consolidation Checkpoint | #166 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-completion-summary.md` (2)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v050x-incorporation-decision-register.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>+1 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-issue-167-approval-quality-consolidation-checkpoint.md` | v0.5.x Issue #167 Approval Quality Consolidation Checkpoint | #167 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-completion-summary.md` (2)<br>`docs/en/status/v050x-follow-up-status.md` (3)<br>`docs/en/status/v050x-incorporation-decision-register.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>+1 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-principal-context-testing-candidate-appendix.md` | v0.5.x Principal Context Testing Candidate Appendix | #161 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md` | v0.5.x Principal Context Testing CSV Refinement Proposal | #161 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-principal-context-testing-proposal.md` | v0.5.x Principal Context Testing Proposal | #161 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-principal-context-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-principal-context-testing-csv-refinement-proposal.md` (3)<br>`docs/en/status/v060-status-document-inventory-planning.md` (3)<br>`docs/en/status/v060-status-document-triage-decision-register.md` (3) | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Candidate Appendix | #166 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-status.md` (6)<br>`docs/en/status/v050x-incorporation-decision-register.md` (3)<br>`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` (3)<br>`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md` (5)<br>+2 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-tamper-evident-evidence-selected-contexts-proposal.md` | v0.5.x Tamper-Evident Evidence Selected Contexts Proposal | #166 | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-follow-up-status.md` (6)<br>`docs/en/status/v050x-incorporation-decision-register.md` (3)<br>`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-candidate-appendix.md` (3)<br>`docs/en/status/v050x-tamper-evident-evidence-selected-contexts-incorporation-decision.md` (3)<br>+2 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-testing-candidate-mapping.md` | v0.5.x Testing Candidate Mapping | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-proposal.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` (3)<br>+9 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-testing-candidate-selection.md` | v0.5.x Testing Candidate Selection | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-proposal.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-testing-proposal.md` (3)<br>+8 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-testing-draft-pass-fail-criteria.md` | v0.5.x Testing Draft Pass/Fail Criteria | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-proposal.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` (3)<br>+8 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-testing-incorporation-readiness-review.md` | v0.5.x Testing Incorporation Readiness Review | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-approval-quality-csv-refinement-proposal.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-proposal.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-csv-refinement-proposal.md` (3)<br>+7 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+| `docs/en/status/v050x-testing-procedure-candidate-matrix.md` | v0.5.x Testing Procedure Candidate Matrix | none | `docs/en/document-map.md` (3)<br>`docs/en/status/README.md` (5) | none | `docs/en/status/v050x-approval-quality-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-approval-quality-testing-proposal.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-testing-candidate-appendix.md` (3)<br>`docs/en/status/v050x-cross-agent-delegation-testing-proposal.md` (3)<br>+7 more | `README.md` (2)<br>`docs/en/55-researcher-overview.md` (3) | reference review required | Review non-index references before archive movement. |
+
+## Interpretation
+
+The readiness labels mean:
+
+| Label | Meaning |
+| --- | --- |
+| `archive path candidate` | No non-index references were detected by the scan. The document may be a candidate for future archive movement after final manual review. |
+| `reference review required` | Non-index references were detected. Review those references before archive movement. |
+
+## Recommended archive preparation policy
+
+Before moving any `archive later` document:
+
+1. Add a historical or supersession header where useful.
+2. Decide whether to use an archive path or keep the document in place with a historical marker.
+3. Update `docs/en/status/README.md`.
+4. Update `docs/en/document-map.md`.
+5. Preserve decision traceability for issues #161 through #167 where applicable.
+6. Re-run validation.
+7. Prefer small PR batches over moving many documents at once.
+
+## Non-goals
+
+This review does not:
+
+- move files
+- delete files
+- archive files
+- promote status material into active guidance
+- replace status documents
+- change active controls
+- change the current control and assessment baseline
+- change schemas, CSV artifacts, examples, or mappings
+
+## Acceptance criteria for this review
+
+This review is sufficient when:
+
+- all `archive later` documents from the decision register are listed
+- reference groups are summarized
+- documents with non-index references are identifiable
+- no file movement is performed
+- no active baseline change is implied
+- roadmap issue #241 can use this review as input for a future archive preparation PR


### PR DESCRIPTION
## Summary

This PR adds the v0.6.0 Status Document Archive Readiness Review.

The review checks references for status documents marked `archive later` in the v0.6.0 Status Document Triage Decision Register before any future archive, movement, replacement, or deletion work.

## Changes

- Adds `docs/en/status/v060-status-document-archive-readiness-review.md`
- Registers the new status document in `docs/en/status/README.md`
- Registers the new status document in `docs/en/document-map.md`

## Scope

This PR is planning/review only.

It does not:

- delete status documents
- archive status documents
- move status documents
- promote status documents into active or adoption-facing guidance
- replace status documents
- change active controls
- change the current control and assessment baseline
- change schemas, CSV artifacts, examples, or mappings

## Review focus

The new review records:

- source decision register reference
- reference scan method
- archive readiness summary
- archive readiness review table for `archive later` documents
- interpretation guidance
- recommended archive preparation policy
- non-goals and acceptance criteria

## Validation

The following validation should pass:

    py tools/validate_markdown_indexes.py

## Related review finding

Supports follow-up for:

- F-04: accumulated temporary status documents require keep / archive / promote triage

## Related PRs

Follow-up to #258, #259, and #260.

## Related issues

Related to #241.
