### PR TITLE
Clean up v0.6.0 status references

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -89,23 +89,24 @@ AAEF v0.6.0 は、それ自体では current active control and assessment basel
 
 AAEF v0.5.0 は prior public review planning release として引き続き参照できます。以前の v0.3.x、v0.2.x、v0.1.x releases は prior public review baselines として引き続き参照できます。
 
-AAEF v0.5.0 に含まれる主な要素:
+AAEF v0.6.0 に含まれる主な要素:
 
-- control catalog versioning and change impact guidance
-- measurable testing procedures and pass criteria
-- machine-readable testing procedure draft
-- High-Impact and Audit-Grade pre-qualification guidance
-- Trusted Control Boundary integrity requirements
-- external framework mapping methodology
-- initial conservative external framework mapping draft
-- validation for testing procedures and external mappings
-- refined control-specific testing procedure pass criteria
-- updated conservative external framework mappings, including NIST AI RMF / GenAI Profile, ISO/IEC 42001 feasibility, and CSA Agentic Trust Framework mapping
-- authority lifecycle planning guidance
-- cross-agent and cross-domain authority planning material
-- evidence integrity and tamper-evident evidence planning material
-- approval quality and approval fatigue planning material
-- v0.5.x follow-up completion status summary
+- Practical Adoption Readiness planning foundation
+- Implementer Readiness planning material
+- Operational Readiness planning material
+- Legal and Compliance Applicability planning material
+- Security Architecture Hardening planning material
+- Risk Owner and Executive Adoption planning material
+- Authorization Decision Artifact Minimal Profile planning draft
+- Implementer Quick Start planning draft
+- Operational Responsibility Matrix planning draft
+- High-Impact Production Minimum Architecture Profile planning draft
+- Legal and Compliance Applicability Note planning draft
+- Risk Owner Guide planning draft
+- repository review follow-up summary
+- status document triage, inventory, decision register, and archive-readiness review
+- external framework mapping CSV enrichment review
+- release preparation planning, release notes draft, release readiness review, and release decision record
 
 AAEF v0.6.0 は公開レビュー planning release です。認証制度、正式標準、implementation conformance claim、audit opinion、compliance equivalence、conformity claim、または完全なリスク軽減を主張するものではありません。
 

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ These documents currently remain under `docs/en/` for public review continuity. 
 
 If you reference this work, please cite it as:
 
-> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.5.0 Public Review Planning Release, 2026.
+> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.6.0 Practical Adoption Readiness Planning Release, 2026.
 
 ## Research and Open Questions
 

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -12,7 +12,7 @@ This document does not create new control requirements and does not change the c
 
 ## Current Status
 
-AAEF v0.5.0 is the latest public review planning release.
+AAEF v0.6.0 Practical Adoption Readiness Planning Release is the latest public review planning release.
 
 AAEF v0.4.1 remains the current control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, testing procedures, or related normative or assessment artifacts.
 


### PR DESCRIPTION
## Summary

This PR cleans up post-release v0.6.0 status references.

It aligns remaining reader-facing status references after the v0.6.0 Practical Adoption Readiness Planning Release.

## Changes

- Aligns README citation wording with the v0.6.0 planning release metadata
- Updates Japanese README v0.6.0 feature/status wording
- Updates the researcher overview to reference v0.6.0 as the latest public review planning release
- Preserves the baseline boundary that v0.6.0 does not, by itself, change the current active control and assessment baseline

## Scope

This PR is post-release documentation cleanup only.

It does not:

- create a release
- create a tag
- update active controls
- change the current control and assessment baseline
- promote planning material into active requirements
- move, delete, archive, replace, or promote status documents
- enrich external mapping CSVs

## Baseline statement

AAEF v0.6.0 is a non-normative planning and adoption-readiness release.

AAEF v0.6.0 does not, by itself, change the current active control and assessment baseline. AAEF v0.4.1 remains the current control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, or testing procedures.

## Validation

The following validation should pass:

    py tools/validate_markdown_indexes.py

## Related release

- v0.6.0 Practical Adoption Readiness Planning Release
- Related to #241
