### PR TITLE
Add adoption package navigation pointers

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,6 +4,15 @@
 
 **AAEF: Agentic AI SystemsのためのAction Assurance Control Profile**
 
+
+## 採用準備向けナビゲーション
+
+役割別の採用・検討ガイドとして、[v0.6.0 adoption package index](docs/en/status/v060-adoption-package-index-planning.md) を参照してください。
+
+実装者、監査人、コンサルタント、運用担当者、リスクオーナー、法務・コンプライアンス担当者、セキュリティアーキテクト、研究者向けの入口を整理しています。
+
+これらは採用準備のための planning material であり、それ自体では current control and assessment baseline を変更しません。
+
 ## 翻訳に関する注意
 
 この文書は、英語版READMEを基にした日本語参考訳です。

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Agentic Authority & Evidence Framework (AAEF) is a practical control framework f
 
 AAEF is designed for AI agents that do more than generate text. It focuses on agents that can call tools, access data, delegate tasks, interact with other agents, and perform meaningful actions on behalf of humans or organizations.
 
+
+## Adoption-readiness navigation
+
+For role-based adoption guidance, see the [v0.6.0 adoption package index](docs/en/status/v060-adoption-package-index-planning.md).
+
+It provides entry points for implementers, auditors, consultants, operators, risk owners, legal/compliance reviewers, security architects, and researchers.
+
+These materials are adoption-readiness planning materials and do not, by themselves, change the current control and assessment baseline.
+
 ## Core Position
 
 AAEF shifts agentic AI security from **trusting model behavior** to **governing authorized action**.


### PR DESCRIPTION
## Summary

This PR adds concise adoption-readiness navigation pointers to README and README.ja for #282.

The links point readers to the v0.6.0 adoption package index as the role-based navigation hub while preserving planning and baseline boundaries.

## Changes

- Adds an adoption-readiness navigation pointer to `README.md`
- Adds an equivalent adoption-readiness navigation pointer to `README.ja.md`

## Scope

This PR updates top-level navigation only.

It does not:

- create a dedicated adoption directory
- promote planning material into active requirements
- change active controls
- change the current control and assessment baseline
- update evidence schema
- update assessment artifacts
- update testing procedures
- assert production readiness
- assert implementation conformance
- assert audit sufficiency
- claim compliance
- claim certification
- claim conformity
- claim equivalence with external frameworks

## Navigation target

- `docs/en/status/v060-adoption-package-index-planning.md`

## Boundary language

The README pointers state that the adoption materials are adoption-readiness planning materials and do not, by themselves, change the current control and assessment baseline.

## Validation

The following validation should pass:

    py tools/validate_markdown_indexes.py
    py tools/validate_json_examples.py
    py tools/validate_external_mappings.py

## Related issue

- Related to #282
- Related to #241
