### PR TITLE
Add v0.6.x risk-owner adoption package refinement planning

### DIFF
--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -268,4 +268,4 @@ It is a navigation and classification aid only.
 ## Operator guidance
 
 - [Operator Guidance](operator-guidance.md) — Operator-facing guidance for reviewing AAEF-style action execution, non-execution, evidence availability, and reconstruction readiness.
-- [v0.6.x Risk Owner Adoption Package Refinement Planning](status/v060-risk-owner-adoption-package-refinement-planning.md) — Plans refinement of the risk-owner adoption package for adoption, exception, and residual-risk decisions.
+- [`docs/en/status/v060-risk-owner-adoption-package-refinement-planning.md`](status/v060-risk-owner-adoption-package-refinement-planning.md) — v0.6.x risk-owner adoption package refinement planning.

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -208,6 +208,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v060-adoption-navigation-integration-planning.md` | v0.6.x adoption navigation integration planning | Plans how v0.6.0 adoption-oriented materials should be discoverable from README, README.ja, document-map, researcher overview, and future adoption entry points while preserving planning and baseline boundaries. |
 | `docs/en/status/v060-operator-runbook-active-guidance-candidate-review.md` | v0.6.x operator runbook active guidance candidate review | Reviews operator runbook planning material for reusable active guidance candidates, organization-specific areas, evidence review expectations, freeze/hold guidance, operational metrics, handoff guidance, and promotion readiness. |
 | `docs/en/status/v060-operator-guidance-placement-and-scope-planning.md` | v0.6.x operator guidance placement and scope planning | Defines the preferred placement and scope for future active operator guidance, including recommended `docs/en/operator-guidance.md` scope, exclusions, handoff guidance, evidence review coverage, and claim boundaries. |
+| `docs/en/status/v060-risk-owner-adoption-package-refinement-planning.md` | v0.6.x risk-owner adoption package refinement planning | Plans refinement of the risk-owner adoption package for adoption, exception, residual-risk, evidence request, decision memo, and executive reporting decisions while preserving claim boundaries. |
 
 ## Numbered Document Coverage Additions
 
@@ -268,4 +269,3 @@ It is a navigation and classification aid only.
 ## Operator guidance
 
 - [Operator Guidance](operator-guidance.md) — Operator-facing guidance for reviewing AAEF-style action execution, non-execution, evidence availability, and reconstruction readiness.
-- [`docs/en/status/v060-risk-owner-adoption-package-refinement-planning.md`](status/v060-risk-owner-adoption-package-refinement-planning.md) — v0.6.x risk-owner adoption package refinement planning.

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -268,3 +268,4 @@ It is a navigation and classification aid only.
 ## Operator guidance
 
 - [Operator Guidance](operator-guidance.md) — Operator-facing guidance for reviewing AAEF-style action execution, non-execution, evidence availability, and reconstruction readiness.
+- [v0.6.x Risk Owner Adoption Package Refinement Planning](status/v060-risk-owner-adoption-package-refinement-planning.md) — Plans refinement of the risk-owner adoption package for adoption, exception, and residual-risk decisions.

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -119,3 +119,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - [`docs/en/status/v060-adoption-navigation-integration-planning.md`](v060-adoption-navigation-integration-planning.md) — v0.6.x adoption navigation integration planning.
 - [`docs/en/status/v060-operator-runbook-active-guidance-candidate-review.md`](v060-operator-runbook-active-guidance-candidate-review.md) — v0.6.x operator runbook active guidance candidate review.
 - [`docs/en/status/v060-operator-guidance-placement-and-scope-planning.md`](v060-operator-guidance-placement-and-scope-planning.md) — v0.6.x operator guidance placement and scope planning.
+- [v0.6.x Risk Owner Adoption Package Refinement Planning](v060-risk-owner-adoption-package-refinement-planning.md) — Plans refinement of the risk-owner adoption package for adoption, exception, and residual-risk decisions.

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -119,4 +119,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - [`docs/en/status/v060-adoption-navigation-integration-planning.md`](v060-adoption-navigation-integration-planning.md) — v0.6.x adoption navigation integration planning.
 - [`docs/en/status/v060-operator-runbook-active-guidance-candidate-review.md`](v060-operator-runbook-active-guidance-candidate-review.md) — v0.6.x operator runbook active guidance candidate review.
 - [`docs/en/status/v060-operator-guidance-placement-and-scope-planning.md`](v060-operator-guidance-placement-and-scope-planning.md) — v0.6.x operator guidance placement and scope planning.
-- [v0.6.x Risk Owner Adoption Package Refinement Planning](v060-risk-owner-adoption-package-refinement-planning.md) — Plans refinement of the risk-owner adoption package for adoption, exception, and residual-risk decisions.
+- [`docs/en/status/v060-risk-owner-adoption-package-refinement-planning.md`](v060-risk-owner-adoption-package-refinement-planning.md) — v0.6.x risk-owner adoption package refinement planning.

--- a/docs/en/status/v060-risk-owner-adoption-package-refinement-planning.md
+++ b/docs/en/status/v060-risk-owner-adoption-package-refinement-planning.md
@@ -1,0 +1,182 @@
+# v0.6.x Risk Owner Adoption Package Refinement Planning
+
+This document plans refinement of the AAEF risk-owner adoption package for the v0.6.x follow-up cycle.
+
+It is a planning artifact for #284. It does not create new active controls, update the evidence schema, update assessment artifacts, or change the current control and assessment baseline.
+
+## Status
+
+Planning artifact.
+
+AAEF v0.4.1 remains the current control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, or testing procedures.
+
+The v0.6.0 and v0.6.x adoption materials remain non-normative unless explicitly promoted into active guidance or active examples.
+
+## Purpose
+
+The purpose of this planning document is to define how the risk-owner adoption package should be refined so that risk owners can use AAEF concepts to make better adoption, exception, and residual-risk decisions.
+
+The refinement should help risk owners understand:
+
+- what decision they are being asked to make,
+- what evidence they should request,
+- what operational signals matter,
+- what claim boundaries apply,
+- what residual risk remains,
+- when to approve, defer, reject, or require additional controls, and
+- how to avoid treating model output as authority.
+
+## Risk-owner audience
+
+The primary audience is a risk owner, business owner, executive sponsor, or governance stakeholder who must decide whether an agentic action system is acceptable for a defined use case.
+
+The risk owner is not assumed to be:
+
+- the model developer,
+- the application developer,
+- the operator,
+- the auditor,
+- the legal owner,
+- the security architect, or
+- the implementation engineer.
+
+The package should therefore avoid assuming deep implementation detail while still preserving the AAEF boundary that authority, enforcement, evidence, and reconstruction must be separately reviewable.
+
+## Refinement goals
+
+The refined risk-owner package should help risk owners:
+
+1. classify the action or use case,
+2. understand high-impact action exposure,
+3. identify who has authority to approve or reject execution,
+4. determine what evidence is needed before adoption,
+5. determine what evidence is needed during operation,
+6. review non-execution and fail-closed behavior,
+7. understand residual risk and exceptions,
+8. document risk acceptance decisions,
+9. understand when to require freeze, hold, or additional review, and
+10. avoid compliance, certification, audit sufficiency, or production readiness overclaims.
+
+## Candidate refined package components
+
+The refined package may include:
+
+- risk-owner decision checklist,
+- high-impact action decision prompts,
+- adoption readiness questions,
+- residual risk review prompts,
+- exception and risk acceptance prompts,
+- evidence request prompts,
+- operator signal review prompts,
+- escalation and handoff questions,
+- claim-boundary language,
+- concise reading path to existing adoption materials, and
+- candidate risk-owner memo structure.
+
+## Decision outcomes
+
+The package should support risk owners in selecting among outcomes such as:
+
+- approve for limited pilot,
+- approve with restrictions,
+- defer pending additional evidence,
+- require additional controls,
+- require additional review by security, legal, compliance, or operations,
+- reject the use case,
+- freeze or hold further execution, or
+- accept residual risk with documented conditions.
+
+These outcomes are illustrative. The package should not define organization-specific approval authority or override internal governance.
+
+## Evidence topics for risk-owner review
+
+Risk owners should be guided to request evidence about:
+
+- action scope,
+- principal or initiating context,
+- authority basis,
+- authorization decision handling,
+- dispatch enforcement,
+- backend relying-party verification,
+- evidence generation,
+- evidence availability,
+- non-execution behavior,
+- reconstruction readiness,
+- operational monitoring,
+- exception handling, and
+- residual-risk ownership.
+
+The package should distinguish evidence useful for risk decisions from evidence sufficient for audit, certification, or legal compliance claims.
+
+## Relationship to operator guidance
+
+The risk-owner package should link to operator-facing guidance where operational signals are relevant.
+
+Operator guidance supports day-to-day review. Risk-owner guidance supports adoption, exception, and residual-risk decisions.
+
+The risk-owner package should not duplicate detailed operator procedures, SIEM/SOAR queries, alert thresholds, staffing models, retention schedules, or incident response procedures.
+
+## Relationship to legal and compliance materials
+
+The risk-owner package should preserve conservative claim boundaries.
+
+It should help risk owners ask legal and compliance questions without asserting that AAEF provides:
+
+- legal advice,
+- compliance advice,
+- certification,
+- conformity assessment,
+- audit opinion,
+- regulatory sufficiency,
+- contractual sufficiency, or
+- equivalence with external frameworks.
+
+External mappings should remain informative relationship mappings, not compliance crosswalks.
+
+## Relationship to implementation materials
+
+The risk-owner package should explain what the risk owner needs from implementers without turning into an implementation guide.
+
+Implementation-facing details should remain in implementer guidance, architecture guidance, examples, schemas, and validation artifacts.
+
+Risk-owner material should focus on decision inputs and outcomes.
+
+## Candidate active guidance target
+
+A later PR may either:
+
+- update `docs/en/status/v060-risk-owner-guide-planning.md`,
+- add a focused active guidance document such as `docs/en/risk-owner-guidance.md`, or
+- add a concise risk-owner package index that links existing adoption materials.
+
+Initial recommendation:
+
+- Use this planning document to define the refinement boundary first.
+- Then add a focused `docs/en/risk-owner-guidance.md` document if the package needs an active, durable entry point.
+- Avoid promoting planning material into requirements unless the baseline is explicitly updated.
+
+## Explicit exclusions
+
+This refinement should not define:
+
+- new controls,
+- new evidence schema fields,
+- new assessment procedures,
+- new testing procedures,
+- organization-specific risk scoring,
+- mandatory approval thresholds,
+- mandatory freeze criteria,
+- incident response procedures,
+- legal conclusions,
+- compliance conclusions,
+- audit sufficiency claims,
+- certification criteria,
+- conformity criteria,
+- production readiness criteria, or
+- equivalence claims with external frameworks.
+
+## Recommended next step
+
+After this planning artifact is reviewed, create a focused risk-owner guidance artifact or targeted update that gives risk owners a concise decision path for AAEF adoption and residual-risk review.
+
+The next implementation PR should remain conservative, role-specific, and claim-boundary safe.


### PR DESCRIPTION
Adds a v0.6.x planning artifact for #284 to refine the risk-owner adoption package.

This PR defines how the risk-owner adoption package should be refined so risk owners can use AAEF concepts for adoption, exception, and residual-risk decisions without changing the active baseline.

Changes:
- Added docs/en/status/v060-risk-owner-adoption-package-refinement-planning.md
- Registered the new status document in docs/en/status/README.md
- Registered the new status document in docs/en/document-map.md

Planning focus:
- risk-owner audience
- refinement goals
- candidate refined package components
- decision outcomes
- evidence topics for risk-owner review
- relationship to operator guidance
- relationship to legal and compliance materials
- relationship to implementation materials
- candidate active guidance target
- explicit exclusions
- recommended next step

Impact:
- Planning documentation only.
- No new controls created.
- No evidence schema updates.
- No assessment artifact updates.
- No testing procedure updates.
- No active baseline change.
- No legal, compliance, audit sufficiency, certification, conformity, production readiness, or external-framework equivalence claim introduced.

Validation:
- py tools/validate_markdown_indexes.py
- py tools/validate_json_examples.py
- py tools/validate_external_mappings.py

Related:
- #284
- #241
- v0.6.0 Practical Adoption Readiness Planning Release