### PR TITLE
Add minimal prototype static fixtures

### DIFF
--- a/examples/prototype/README.md
+++ b/examples/prototype/README.md
@@ -132,6 +132,32 @@ This directory does not currently provide:
 - audit opinion support, or
 - legal advice.
 
+## Current static fixtures
+
+This directory now includes minimal static fixture examples for two illustrative paths:
+
+- `fixtures/permitted/` — a permitted action path with request, authorization decision, dispatch decision, backend verification, evidence event, and reconstruction notes.
+- `fixtures/non-execution/` — a non-execution path with request, authorization decision, dispatch refusal, backend non-execution, evidence event, and reconstruction notes.
+
+These fixtures are static JSON examples only.
+
+They do not provide:
+
+- executable prototype behavior,
+- runtime authorization,
+- runtime dispatch enforcement,
+- backend service behavior,
+- validation-backed assurance,
+- implementation conformance,
+- production readiness,
+- audit sufficiency,
+- legal sufficiency,
+- compliance sufficiency,
+- certification, or
+- conformity.
+
+A later PR may add local validation for these fixtures.
+
 ## Next step
 
 The next safe step is to add static fixtures for a permitted path and a non-execution path, or to define validation planning for such fixtures.

--- a/examples/prototype/fixtures/non-execution/action-request.example.json
+++ b/examples/prototype/fixtures/non-execution/action-request.example.json
@@ -1,0 +1,30 @@
+{
+  "fixture_type": "action_request",
+  "path": "non-execution",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-nonexecution-001",
+  "action_request_id": "proto-req-nonexecution-001",
+  "action_type": "prototype.customer_record.export",
+  "requested_by": {
+    "principal_type": "prototype_user",
+    "principal_id": "prototype-user-001"
+  },
+  "target": {
+    "resource_type": "customer_record",
+    "resource_id": "customer-record-001"
+  },
+  "requested_outcome": "execute_if_authorized",
+  "model_output_role": "proposal_only",
+  "model_output_is_authority": false,
+  "notes": "Static request fixture for an illustrative non-execution path."
+}

--- a/examples/prototype/fixtures/non-execution/authorization-decision.example.json
+++ b/examples/prototype/fixtures/non-execution/authorization-decision.example.json
@@ -1,0 +1,29 @@
+{
+  "fixture_type": "authorization_decision",
+  "path": "non-execution",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-nonexecution-001",
+  "authorization_decision_id": "proto-authz-nonexecution-001",
+  "action_request_id": "proto-req-nonexecution-001",
+  "action_type": "prototype.customer_record.export",
+  "policy_version": "prototype-policy-v0.1",
+  "decision": "deny",
+  "decision_scope": {
+    "denied_action_type": "prototype.customer_record.export",
+    "denied_resource_id": "customer-record-001"
+  },
+  "reason": "authorization_scope_not_approved_for_export",
+  "authority_basis": "prototype_fixture_policy",
+  "model_output_is_authority": false,
+  "notes": "Static authorization fixture showing denial for an export-like action."
+}

--- a/examples/prototype/fixtures/non-execution/backend-verification.example.json
+++ b/examples/prototype/fixtures/non-execution/backend-verification.example.json
@@ -1,0 +1,28 @@
+{
+  "fixture_type": "backend_verification",
+  "path": "non-execution",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-nonexecution-001",
+  "backend_verification_id": "proto-backend-nonexecution-001",
+  "dispatch_decision_id": "proto-dispatch-nonexecution-001",
+  "authorization_decision_id": "proto-authz-nonexecution-001",
+  "action_type": "prototype.customer_record.export",
+  "backend_decision": "not_invoked_after_dispatch_refusal",
+  "checks": {
+    "dispatch_forwarded_to_backend": false,
+    "backend_execution_occurred": false,
+    "model_output_treated_as_authority": false
+  },
+  "reason": "dispatch_refused_before_backend_execution",
+  "notes": "Static backend fixture showing that backend execution does not occur after dispatch refusal."
+}

--- a/examples/prototype/fixtures/non-execution/dispatch-decision.example.json
+++ b/examples/prototype/fixtures/non-execution/dispatch-decision.example.json
@@ -1,0 +1,29 @@
+{
+  "fixture_type": "dispatch_decision",
+  "path": "non-execution",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-nonexecution-001",
+  "dispatch_decision_id": "proto-dispatch-nonexecution-001",
+  "action_request_id": "proto-req-nonexecution-001",
+  "authorization_decision_id": "proto-authz-nonexecution-001",
+  "action_type": "prototype.customer_record.export",
+  "dispatch_decision": "refuse_dispatch",
+  "checks": {
+    "authorization_present": true,
+    "authorization_allows_requested_action": false,
+    "model_output_treated_as_authority": false,
+    "fail_closed": true
+  },
+  "reason": "authorization_denied",
+  "notes": "Static dispatch fixture showing fail-closed non-execution."
+}

--- a/examples/prototype/fixtures/non-execution/evidence-event.example.json
+++ b/examples/prototype/fixtures/non-execution/evidence-event.example.json
@@ -1,0 +1,31 @@
+{
+  "fixture_type": "evidence_event",
+  "path": "non-execution",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-nonexecution-001",
+  "evidence_event_id": "proto-evidence-nonexecution-001",
+  "action_request_id": "proto-req-nonexecution-001",
+  "authorization_decision_id": "proto-authz-nonexecution-001",
+  "dispatch_decision_id": "proto-dispatch-nonexecution-001",
+  "backend_verification_id": "proto-backend-nonexecution-001",
+  "action_type": "prototype.customer_record.export",
+  "outcome": "not_executed",
+  "reason": "authorization_denied_and_dispatch_refused",
+  "evidence_summary": {
+    "authority_separated_from_model_output": true,
+    "dispatch_enforcement_observed": true,
+    "backend_execution_prevented": true,
+    "reconstructable_from_static_fixtures": true
+  },
+  "notes": "Static evidence fixture for an illustrative non-execution path."
+}

--- a/examples/prototype/fixtures/non-execution/reconstruction-notes.example.json
+++ b/examples/prototype/fixtures/non-execution/reconstruction-notes.example.json
@@ -1,0 +1,25 @@
+{
+  "fixture_type": "reconstruction_notes",
+  "path": "non-execution",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-nonexecution-001",
+  "reconstruction_path": [
+    "proto-req-nonexecution-001",
+    "proto-authz-nonexecution-001",
+    "proto-dispatch-nonexecution-001",
+    "proto-backend-nonexecution-001",
+    "proto-evidence-nonexecution-001"
+  ],
+  "expected_reviewer_conclusion": "The action is represented as not executed because authorization denies the requested export-like action, dispatch refuses forwarding, backend execution does not occur, and evidence records the non-execution outcome.",
+  "notes": "Static reconstruction notes for the non-execution path."
+}

--- a/examples/prototype/fixtures/permitted/action-request.example.json
+++ b/examples/prototype/fixtures/permitted/action-request.example.json
@@ -1,0 +1,30 @@
+{
+  "fixture_type": "action_request",
+  "path": "permitted",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-permitted-001",
+  "action_request_id": "proto-req-permitted-001",
+  "action_type": "prototype.customer_record.read",
+  "requested_by": {
+    "principal_type": "prototype_user",
+    "principal_id": "prototype-user-001"
+  },
+  "target": {
+    "resource_type": "customer_record",
+    "resource_id": "customer-record-001"
+  },
+  "requested_outcome": "execute_if_authorized",
+  "model_output_role": "proposal_only",
+  "model_output_is_authority": false,
+  "notes": "Static request fixture for an illustrative permitted path."
+}

--- a/examples/prototype/fixtures/permitted/authorization-decision.example.json
+++ b/examples/prototype/fixtures/permitted/authorization-decision.example.json
@@ -1,0 +1,32 @@
+{
+  "fixture_type": "authorization_decision",
+  "path": "permitted",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-permitted-001",
+  "authorization_decision_id": "proto-authz-permitted-001",
+  "action_request_id": "proto-req-permitted-001",
+  "action_type": "prototype.customer_record.read",
+  "policy_version": "prototype-policy-v0.1",
+  "decision": "allow",
+  "decision_scope": {
+    "allowed_action_type": "prototype.customer_record.read",
+    "allowed_resource_id": "customer-record-001"
+  },
+  "validity": {
+    "not_before": "2026-05-02T00:00:00Z",
+    "not_after": "2026-05-03T00:00:00Z"
+  },
+  "authority_basis": "prototype_fixture_policy",
+  "model_output_is_authority": false,
+  "notes": "Static authorization fixture showing action-bound authority for the permitted path."
+}

--- a/examples/prototype/fixtures/permitted/backend-verification.example.json
+++ b/examples/prototype/fixtures/permitted/backend-verification.example.json
@@ -1,0 +1,28 @@
+{
+  "fixture_type": "backend_verification",
+  "path": "permitted",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-permitted-001",
+  "backend_verification_id": "proto-backend-permitted-001",
+  "dispatch_decision_id": "proto-dispatch-permitted-001",
+  "authorization_decision_id": "proto-authz-permitted-001",
+  "action_type": "prototype.customer_record.read",
+  "backend_decision": "accept",
+  "checks": {
+    "authorization_reference_received": true,
+    "authorization_decision_verified": true,
+    "caller_intent_only": false,
+    "model_output_treated_as_authority": false
+  },
+  "notes": "Static backend fixture showing relying-party verification for the permitted path."
+}

--- a/examples/prototype/fixtures/permitted/dispatch-decision.example.json
+++ b/examples/prototype/fixtures/permitted/dispatch-decision.example.json
@@ -1,0 +1,28 @@
+{
+  "fixture_type": "dispatch_decision",
+  "path": "permitted",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-permitted-001",
+  "dispatch_decision_id": "proto-dispatch-permitted-001",
+  "action_request_id": "proto-req-permitted-001",
+  "authorization_decision_id": "proto-authz-permitted-001",
+  "action_type": "prototype.customer_record.read",
+  "dispatch_decision": "forward_to_backend",
+  "checks": {
+    "authorization_present": true,
+    "authorization_action_matches_request": true,
+    "authorization_not_expired": true,
+    "model_output_treated_as_authority": false
+  },
+  "notes": "Static dispatch fixture showing enforcement before backend forwarding."
+}

--- a/examples/prototype/fixtures/permitted/evidence-event.example.json
+++ b/examples/prototype/fixtures/permitted/evidence-event.example.json
@@ -1,0 +1,30 @@
+{
+  "fixture_type": "evidence_event",
+  "path": "permitted",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-permitted-001",
+  "evidence_event_id": "proto-evidence-permitted-001",
+  "action_request_id": "proto-req-permitted-001",
+  "authorization_decision_id": "proto-authz-permitted-001",
+  "dispatch_decision_id": "proto-dispatch-permitted-001",
+  "backend_verification_id": "proto-backend-permitted-001",
+  "action_type": "prototype.customer_record.read",
+  "outcome": "executed",
+  "evidence_summary": {
+    "authority_separated_from_model_output": true,
+    "dispatch_enforcement_observed": true,
+    "backend_verification_observed": true,
+    "reconstructable_from_static_fixtures": true
+  },
+  "notes": "Static evidence fixture for an illustrative executed path."
+}

--- a/examples/prototype/fixtures/permitted/reconstruction-notes.example.json
+++ b/examples/prototype/fixtures/permitted/reconstruction-notes.example.json
@@ -1,0 +1,25 @@
+{
+  "fixture_type": "reconstruction_notes",
+  "path": "permitted",
+  "is_static_fixture": true,
+  "is_executable": false,
+  "claim_boundary": [
+    "illustrative_example_only",
+    "not_validation_backed",
+    "not_implementation_conformance",
+    "not_production_readiness",
+    "not_audit_sufficiency",
+    "not_legal_or_compliance_advice",
+    "not_certification_or_conformity"
+  ],
+  "correlation_id": "proto-corr-permitted-001",
+  "reconstruction_path": [
+    "proto-req-permitted-001",
+    "proto-authz-permitted-001",
+    "proto-dispatch-permitted-001",
+    "proto-backend-permitted-001",
+    "proto-evidence-permitted-001"
+  ],
+  "expected_reviewer_conclusion": "The action is represented as executed only after separate authorization, dispatch enforcement, backend verification, and evidence generation are present in the static fixture set.",
+  "notes": "Static reconstruction notes for the permitted path."
+}


### PR DESCRIPTION
Adds minimal static prototype fixtures for #285.

This PR follows the prototype fixture planning and fixture validation planning work by adding static JSON examples for one permitted path and one non-execution path.

Changes:
- Added permitted path static fixtures under `examples/prototype/fixtures/permitted/`
- Added non-execution path static fixtures under `examples/prototype/fixtures/non-execution/`
- Updated `examples/prototype/README.md` to describe the current static fixtures and claim boundaries

Permitted path fixtures:
- `action-request.example.json`
- `authorization-decision.example.json`
- `dispatch-decision.example.json`
- `backend-verification.example.json`
- `evidence-event.example.json`
- `reconstruction-notes.example.json`

Non-execution path fixtures:
- `action-request.example.json`
- `authorization-decision.example.json`
- `dispatch-decision.example.json`
- `backend-verification.example.json`
- `evidence-event.example.json`
- `reconstruction-notes.example.json`

Scope:
- Static JSON examples only.
- Illustrates one permitted action path.
- Illustrates one non-execution path.
- Preserves the distinction between model output, authority, dispatch enforcement, backend verification, evidence, and reconstruction.

Impact:
- No executable prototype code added.
- No validators added.
- No CI workflow changes added.
- No SDK-specific or cloud-specific implementation added.
- No production service code added.
- No reference architecture mandate created.
- No new controls created.
- No evidence schema updates.
- No assessment artifact updates.
- No testing procedure updates.
- No active baseline change.
- No implementation conformance, production readiness, legal, compliance, audit sufficiency, certification, conformity, or external-framework equivalence claim introduced.

Validation:
- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_external_mappings.py`

Result:
- Markdown indexes validated.
- JSON example validation passed for 14 files.
- External mapping validation passed.

Related:
- #285
- #241
- v0.6.0 Practical Adoption Readiness Planning Release
