### PR TITLE
Add v0.6.x research related-work mapping planning

### DIFF
--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -213,6 +213,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v060-prototype-placement-and-file-inventory-planning.md` | v0.6.x prototype placement and file inventory planning | Defines conservative placement and file-inventory planning for future prototype materials, including `examples/prototype/`, non-executable README scope, later fixture candidates, validation planning, maintenance considerations, and claim boundaries. |
 | `docs/en/status/v060-prototype-static-fixture-planning.md` | v0.6.x prototype static fixture planning | Defines the planned static fixture set for future prototype examples, including permitted and non-execution paths, candidate fixture names, correlation expectations, validation planning, sequencing, maintenance considerations, and claim boundaries. |
 | `docs/en/status/v060-prototype-fixture-validation-planning.md` | v0.6.x prototype fixture validation planning | Defines planned validation boundaries for future prototype static fixtures, including required files, JSON syntax, field presence, correlation consistency, permitted/non-execution path checks, claim-boundary checks, sequencing, and non-goals. |
+| `docs/en/status/v060-research-related-work-mapping-planning.md` | v0.6.x research related-work mapping planning | Defines conservative planning boundaries for future research related-work mapping, including source eligibility, mapping dimensions, claim boundaries, novelty language, validation review, and explicit exclusions. |
 
 ## Numbered Document Coverage Additions
 

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -124,3 +124,4 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - [`docs/en/status/v060-prototype-placement-and-file-inventory-planning.md`](v060-prototype-placement-and-file-inventory-planning.md) — v0.6.x prototype placement and file inventory planning.
 - [`docs/en/status/v060-prototype-static-fixture-planning.md`](v060-prototype-static-fixture-planning.md) — v0.6.x prototype static fixture planning.
 - [`docs/en/status/v060-prototype-fixture-validation-planning.md`](v060-prototype-fixture-validation-planning.md) — v0.6.x prototype fixture validation planning.
+- [`docs/en/status/v060-research-related-work-mapping-planning.md`](v060-research-related-work-mapping-planning.md) — v0.6.x research related-work mapping planning.

--- a/docs/en/status/v060-research-related-work-mapping-planning.md
+++ b/docs/en/status/v060-research-related-work-mapping-planning.md
@@ -1,0 +1,228 @@
+# v0.6.x Research Related-Work Mapping Planning
+
+This document defines a conservative planning boundary for future AAEF research related-work mapping.
+
+It is a planning artifact for #286. It does not add an external framework equivalence claim, compliance crosswalk, certification mapping, formal literature review, legal conclusion, audit conclusion, or normative framework relationship.
+
+## Status
+
+Planning artifact.
+
+AAEF v0.4.1 remains the current control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, or testing procedures.
+
+The v0.6.0 and v0.6.x adoption materials remain non-normative unless explicitly promoted into active guidance or active examples.
+
+## Purpose
+
+The purpose of this planning document is to define how AAEF should prepare a research related-work mapping without overclaiming novelty, equivalence, compliance, certification, or formal academic coverage.
+
+The mapping should help readers understand where AAEF sits relative to adjacent research and practice areas while preserving the core AAEF boundary:
+
+> Model output is not authority.
+
+## Mapping goals
+
+A future related-work mapping should help explain:
+
+- which research and practice areas are adjacent to AAEF,
+- which problems AAEF directly addresses,
+- which problems AAEF intentionally does not address,
+- where AAEF appears complementary rather than equivalent,
+- where AAEF may need stronger references,
+- where terminology may overlap with existing work,
+- where novelty claims should be avoided or softened, and
+- what evidence would be needed before making stronger research claims.
+
+## Candidate related-work categories
+
+A future mapping may include categories such as:
+
+- agentic AI security and control boundaries,
+- tool-use and function-calling authorization,
+- prompt injection and indirect prompt injection defenses,
+- human approval and human-in-the-loop control,
+- authorization and policy decision architecture,
+- evidence, audit logging, and reconstruction,
+- provenance and tamper-evident records,
+- governance, risk, and accountability frameworks,
+- AI assurance and AI risk management,
+- operational monitoring and incident response,
+- software supply chain and runtime enforcement,
+- safety cases and assurance cases, and
+- compliance-adjacent control mapping.
+
+These categories are candidates only. A later PR should decide the exact structure.
+
+## Source eligibility planning
+
+A future related-work mapping should prefer sources that are:
+
+- primary standards or framework documents,
+- peer-reviewed academic papers,
+- official technical documentation,
+- reputable industry reports,
+- well-scoped security research writeups,
+- project-maintained public documentation, or
+- clearly labeled public review drafts.
+
+Where possible, the mapping should distinguish:
+
+- academic research,
+- standards and frameworks,
+- industry guidance,
+- implementation documentation,
+- incident or case-study material, and
+- AAEF internal design artifacts.
+
+## Source exclusion planning
+
+A future mapping should avoid relying on:
+
+- unsourced marketing claims,
+- vendor-only claims without technical support,
+- informal social posts as primary evidence,
+- unclear summaries of standards,
+- stale drafts where a newer authoritative version exists,
+- claims that cannot be traced to a source,
+- sources that assert legal or compliance sufficiency without context, and
+- sources used only to imply equivalence.
+
+## Mapping dimensions
+
+A future mapping may compare related work across dimensions such as:
+
+- authority separation,
+- execution enforcement,
+- action-bound evidence,
+- backend verification,
+- non-execution evidence,
+- reconstruction support,
+- human approval scope,
+- policy and authorization model,
+- runtime control boundary,
+- audit and assurance posture,
+- governance and risk-owner decision support,
+- operational monitoring,
+- implementation neutrality, and
+- claim boundaries.
+
+The mapping should avoid scoring unless a later PR defines a conservative scoring method.
+
+## Claim boundaries
+
+A related-work mapping should not claim that AAEF:
+
+- is equivalent to an external framework,
+- satisfies an external standard,
+- provides compliance sufficiency,
+- provides audit sufficiency,
+- provides certification criteria,
+- provides conformity criteria,
+- proves legal adequacy,
+- is production-ready,
+- is a complete security architecture,
+- replaces existing AI risk frameworks,
+- replaces existing authorization models, or
+- replaces software assurance, governance, or incident response practices.
+
+The mapping may describe relationships, overlaps, gaps, and complementary roles.
+
+## Novelty language planning
+
+Novelty claims should be conservative.
+
+Acceptable wording may include:
+
+- AAEF emphasizes action authority rather than model output trust.
+- AAEF focuses on action-bound evidence and reconstruction for agentic systems.
+- AAEF is positioned as a control profile and adoption aid, not a standard or certification scheme.
+- AAEF may complement existing AI risk and security frameworks.
+
+Avoid stronger claims such as:
+
+- AAEF is the first framework to solve this problem.
+- AAEF fully covers agentic AI security.
+- AAEF proves compliance.
+- AAEF is equivalent to an established standard.
+- AAEF makes agentic systems safe.
+
+## Research output options
+
+A later PR may create one or more of the following:
+
+- `docs/en/status/v060-research-related-work-candidate-map.md`,
+- `docs/en/research-related-work.md`,
+- a table of related-work categories,
+- a citation inventory,
+- a gap and overlap matrix,
+- a conservative novelty statement,
+- a research positioning memo, or
+- a publication-oriented related-work outline.
+
+Initial recommendation:
+
+- First create a candidate related-work map as a status artifact.
+- Keep citations and relationship claims conservative.
+- Promote to an active research-facing document only after the candidate map is reviewed.
+
+## Relationship to existing mappings
+
+AAEF already includes external framework mapping artifacts.
+
+A research related-work mapping should not replace those mappings.
+
+It should distinguish:
+
+- framework relationship mapping,
+- research related-work positioning,
+- compliance-adjacent mapping,
+- implementation guidance, and
+- active baseline artifacts.
+
+## Validation and review planning
+
+A future related-work mapping should be reviewed for:
+
+- source traceability,
+- outdated references,
+- unsupported novelty claims,
+- accidental equivalence claims,
+- compliance overclaims,
+- unclear distinction between research and implementation,
+- unclear distinction between AAEF artifacts and external sources,
+- terminology conflict,
+- missing adjacent domains, and
+- overbroad scope.
+
+If a future mapping includes tables, validation may include Markdown index checks and link/reference consistency checks where practical.
+
+## Explicit exclusions
+
+This planning document does not add:
+
+- a completed related-work map,
+- external framework equivalence claims,
+- compliance crosswalks,
+- certification mappings,
+- conformity mappings,
+- legal conclusions,
+- audit conclusions,
+- production readiness claims,
+- implementation conformance criteria,
+- new controls,
+- new evidence schema fields,
+- new assessment procedures,
+- new testing procedures, or
+- active baseline changes.
+
+## Recommended next step
+
+After this planning artifact is reviewed, create a candidate related-work map as a status document.
+
+The next PR should remain conservative and should separate:
+
+- source inventory,
+- relationship descriptions,
+- gaps and overlaps,
+- novelty language, and
+- explicit claim boundaries.


### PR DESCRIPTION
Adds a v0.6.x planning artifact for #286 to define conservative research related-work mapping boundaries.

This PR prepares AAEF for future research related-work mapping by defining source eligibility, mapping dimensions, novelty language, claim boundaries, and review expectations before adding a related-work map or citation inventory.

Changes:
- Added docs/en/status/v060-research-related-work-mapping-planning.md
- Registered the new status document in docs/en/status/README.md
- Registered the new status document in docs/en/document-map.md

Planning focus:
- mapping goals
- candidate related-work categories
- source eligibility planning
- source exclusion planning
- mapping dimensions
- claim boundaries
- novelty language planning
- research output options
- relationship to existing mappings
- validation and review planning
- explicit exclusions
- recommended next step

Impact:
- Planning documentation only.
- No completed related-work map added.
- No citation inventory added.
- No external framework equivalence claim added.
- No compliance crosswalk added.
- No certification or conformity mapping added.
- No legal, audit, empirical validation, standardization, or production readiness claim introduced.
- No new controls created.
- No evidence schema updates.
- No assessment artifact updates.
- No testing procedure updates.
- No active baseline change.

Validation:
- py tools/validate_markdown_indexes.py
- py tools/validate_json_examples.py
- py tools/validate_external_mappings.py

Related:
- #286
- #241
- v0.6.0 Practical Adoption Readiness Planning Release
