### PR TITLE
Add evidence example hygiene validator

### DIFF
--- a/.github/workflows/validate-aaef-artifacts.yml
+++ b/.github/workflows/validate-aaef-artifacts.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Validate JSON examples
         run: python tools/validate_json_examples.py
+        run: python tools/validate_evidence_examples.py
 
       - name: Validate assessment profile mapping
         run: python tools/validate_assessment_profiles.py

--- a/.github/workflows/validate-aaef-artifacts.yml
+++ b/.github/workflows/validate-aaef-artifacts.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Validate JSON examples
         run: python tools/validate_json_examples.py
+
+      - name: Validate evidence examples
         run: python tools/validate_evidence_examples.py
 
       - name: Validate assessment profile mapping

--- a/examples/evidence/README.md
+++ b/examples/evidence/README.md
@@ -67,3 +67,27 @@ They may support:
 - `docs/en/status/v060-active-example-placement-and-validation-planning.md`
 - `docs/en/status/v060-permitted-action-evidence-example-planning.md`
 - `docs/en/status/v060-non-execution-evidence-example-planning.md`
+
+## Evidence example hygiene validation
+
+The evidence examples in this directory are illustrative active example candidates.
+
+They are:
+
+- intended to support reviewability of permitted-action and non-execution evidence patterns;
+- intended to support local validation of example hygiene;
+- not production-ready evidence records;
+- not implementation conformance tests;
+- not audit sufficiency evidence by themselves;
+- not compliance evidence by themselves;
+- not certification evidence;
+- not conformity evidence;
+- not external-framework equivalence evidence.
+
+Run the dedicated evidence example hygiene validator with:
+
+    py tools/validate_evidence_examples.py
+
+This validator checks example file presence, `.example.json` naming, illustrative metadata, scenario type, selected identifier hygiene, forbidden overclaiming phrases, and README claim-boundary coverage.
+
+This validator does not assert active evidence schema conformance, implementation conformance, production readiness, audit sufficiency, legal sufficiency, compliance, certification, conformity, or external-framework equivalence.

--- a/examples/evidence/non-execution-evidence.example.json
+++ b/examples/evidence/non-execution-evidence.example.json
@@ -1,7 +1,7 @@
 {
   "example_metadata": {
     "example_name": "Non-execution evidence example",
-    "example_status": "active_example_candidate",
+    "example_status": "illustrative_candidate",
     "example_version": "v0.6.x",
     "scenario": "A proposed production service API key rotation is denied because the requested key slot exceeds the authorized scope.",
     "outcome": "not_executed",
@@ -11,20 +11,25 @@
       "cross_reference_validation": "deferred",
       "controlled_vocabulary_validation": "deferred"
     },
-    "claim_boundaries": [
-      "does_not_assert_certification",
-      "does_not_assert_compliance",
-      "does_not_assert_audit_sufficiency",
-      "does_not_assert_implementation_conformance",
-      "does_not_assert_production_readiness",
-      "does_not_assert_external_framework_equivalence",
-      "does_not_assert_complete_mitigation"
-    ],
+    "claim_boundaries": {
+      "production_readiness": false,
+      "implementation_conformance": false,
+      "audit_sufficiency": false,
+      "compliance": false,
+      "certification": false,
+      "conformity": false,
+      "external_framework_equivalence": false
+    },
     "related_planning_artifacts": [
       "docs/en/status/v060-non-execution-evidence-example-planning.md",
       "docs/en/status/v060-active-evidence-example-candidate-review.md",
       "docs/en/status/v060-active-example-placement-and-validation-planning.md"
-    ]
+    ],
+    "scenario_type": "non_execution",
+    "normative_status": "non_normative",
+    "schema_conformance": "not_asserted",
+    "implementation_conformance": "not_asserted",
+    "evidence_sufficiency": "not_asserted"
   },
   "action_request": {
     "action_request_id": "arq-20260502-0002",
@@ -62,7 +67,7 @@
   },
   "available_authorization_decision": {
     "authorization_decision_id": "auz-20260502-0001",
-    "action_request_id": "arq-20260502-0001",
+    "action_request_id": "arq-20260502-0002",
     "decision": "permit",
     "principal_id": "user:ops-engineer-17",
     "authorized_action": "rotate_service_api_key",

--- a/examples/evidence/permitted-action-evidence.example.json
+++ b/examples/evidence/permitted-action-evidence.example.json
@@ -1,7 +1,7 @@
 {
   "example_metadata": {
     "example_name": "Permitted action evidence example",
-    "example_status": "active_example_candidate",
+    "example_status": "illustrative_candidate",
     "example_version": "v0.6.x",
     "scenario": "A bounded production service API key rotation is permitted after authorization, dispatch enforcement, and backend verification.",
     "outcome": "executed",
@@ -11,20 +11,25 @@
       "cross_reference_validation": "deferred",
       "controlled_vocabulary_validation": "deferred"
     },
-    "claim_boundaries": [
-      "does_not_assert_certification",
-      "does_not_assert_compliance",
-      "does_not_assert_audit_sufficiency",
-      "does_not_assert_implementation_conformance",
-      "does_not_assert_production_readiness",
-      "does_not_assert_external_framework_equivalence",
-      "does_not_assert_complete_mitigation"
-    ],
+    "claim_boundaries": {
+      "production_readiness": false,
+      "implementation_conformance": false,
+      "audit_sufficiency": false,
+      "compliance": false,
+      "certification": false,
+      "conformity": false,
+      "external_framework_equivalence": false
+    },
     "related_planning_artifacts": [
       "docs/en/status/v060-permitted-action-evidence-example-planning.md",
       "docs/en/status/v060-active-evidence-example-candidate-review.md",
       "docs/en/status/v060-active-example-placement-and-validation-planning.md"
-    ]
+    ],
+    "scenario_type": "permitted_action",
+    "normative_status": "non_normative",
+    "schema_conformance": "not_asserted",
+    "implementation_conformance": "not_asserted",
+    "evidence_sufficiency": "not_asserted"
   },
   "action_request": {
     "action_request_id": "arq-20260502-0001",

--- a/tools/validate_evidence_examples.py
+++ b/tools/validate_evidence_examples.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE_DIR = ROOT / "examples" / "evidence"
+README = EVIDENCE_DIR / "README.md"
+
+EXPECTED_EXAMPLES = {
+    "permitted-action-evidence.example.json": "permitted_action",
+    "non-execution-evidence.example.json": "non_execution",
+}
+
+REQUIRED_METADATA = {
+    "example_status": {"illustrative_candidate"},
+    "normative_status": {"non_normative"},
+    "schema_conformance": {"not_asserted"},
+    "implementation_conformance": {"not_asserted"},
+    "evidence_sufficiency": {"not_asserted"},
+}
+
+REQUIRED_FALSE_CLAIM_BOUNDARIES = [
+    "production_readiness",
+    "implementation_conformance",
+    "audit_sufficiency",
+    "compliance",
+    "certification",
+    "conformity",
+    "external_framework_equivalence",
+]
+
+README_REQUIRED_PHRASES = [
+    "not production-ready",
+    "not implementation conformance",
+    "not audit sufficiency",
+    "not compliance",
+    "not certification",
+    "not conformity",
+    "not external-framework equivalence",
+]
+
+FORBIDDEN_STRING_PHRASES = [
+    "production-ready",
+    "certified",
+    "audit sufficient",
+    "legally sufficient",
+    "equivalent to",
+    "guarantees",
+    "proves safety",
+    "validated implementation",
+]
+
+
+def error(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def load_json(path: Path, errors: list[str]) -> Any | None:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except json.JSONDecodeError as exc:
+        error(errors, f"{path.relative_to(ROOT)}: invalid JSON: {exc}")
+    except OSError as exc:
+        error(errors, f"{path.relative_to(ROOT)}: cannot read file: {exc}")
+    return None
+
+
+def iter_strings(value: Any, path: str = "$") -> list[tuple[str, str]]:
+    strings: list[tuple[str, str]] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            strings.extend(iter_strings(nested, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            strings.extend(iter_strings(nested, f"{path}[{index}]"))
+    elif isinstance(value, str):
+        strings.append((path, value))
+    return strings
+
+
+def iter_ids(value: Any, path: str = "$") -> list[tuple[str, str, Any]]:
+    ids: list[tuple[str, str, Any]] = []
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            next_path = f"{path}.{key}"
+            if key.endswith("_id") or key == "id":
+                ids.append((next_path, key, nested))
+            ids.extend(iter_ids(nested, next_path))
+    elif isinstance(value, list):
+        for index, nested in enumerate(value):
+            ids.extend(iter_ids(nested, f"{path}[{index}]"))
+    return ids
+
+
+def validate_readme(errors: list[str]) -> None:
+    if not README.exists():
+        error(errors, f"{README.relative_to(ROOT)}: missing evidence example README")
+        return
+
+    content = README.read_text(encoding="utf-8").lower()
+    for phrase in README_REQUIRED_PHRASES:
+        if phrase not in content:
+            error(errors, f"{README.relative_to(ROOT)}: missing required claim-boundary phrase: {phrase!r}")
+
+
+def validate_metadata(path: Path, data: dict[str, Any], expected_scenario_type: str, errors: list[str]) -> None:
+    metadata = data.get("example_metadata")
+    if not isinstance(metadata, dict):
+        error(errors, f"{path.relative_to(ROOT)}: missing object field example_metadata")
+        return
+
+    scenario_type = metadata.get("scenario_type")
+    if scenario_type != expected_scenario_type:
+        error(
+            errors,
+            f"{path.relative_to(ROOT)}: example_metadata.scenario_type must be "
+            f"{expected_scenario_type!r}, got {scenario_type!r}",
+        )
+
+    for field, allowed_values in REQUIRED_METADATA.items():
+        value = metadata.get(field)
+        if value not in allowed_values:
+            allowed = ", ".join(sorted(repr(v) for v in allowed_values))
+            error(errors, f"{path.relative_to(ROOT)}: example_metadata.{field} must be one of {allowed}, got {value!r}")
+
+    boundaries = metadata.get("claim_boundaries")
+    if not isinstance(boundaries, dict):
+        error(errors, f"{path.relative_to(ROOT)}: example_metadata.claim_boundaries must be an object")
+        return
+
+    for field in REQUIRED_FALSE_CLAIM_BOUNDARIES:
+        if boundaries.get(field) is not False:
+            error(errors, f"{path.relative_to(ROOT)}: example_metadata.claim_boundaries.{field} must be false")
+
+
+def validate_identifier_hygiene(path: Path, data: dict[str, Any], errors: list[str]) -> None:
+    # Evidence examples may intentionally use null identifiers when a component was not invoked.
+    # This is especially important for non-execution examples where backend verification may not exist.
+    for id_path, key, value in iter_ids(data):
+        if id_path.startswith("$.example_metadata."):
+            continue
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            error(errors, f"{path.relative_to(ROOT)}: {id_path} must be a string identifier or null")
+        elif not value.strip():
+            error(errors, f"{path.relative_to(ROOT)}: {id_path} must not be empty")
+
+    correlated_keys = {
+        "action_request_id",
+        "authorization_decision_id",
+        "dispatch_decision_id",
+        "backend_verification_id",
+        "evidence_event_id",
+    }
+    values_by_key: dict[str, set[str]] = {key: set() for key in correlated_keys}
+    for _id_path, key, value in iter_ids(data):
+        if key in correlated_keys and isinstance(value, str) and value.strip():
+            values_by_key[key].add(value)
+
+    for key, values in values_by_key.items():
+        if len(values) > 1:
+            error(
+                errors,
+                f"{path.relative_to(ROOT)}: inconsistent {key} values within example: {sorted(values)!r}",
+            )
+
+
+def validate_forbidden_claims(path: Path, data: dict[str, Any], errors: list[str]) -> None:
+    for string_path, value in iter_strings(data):
+        lower = value.lower()
+        for phrase in FORBIDDEN_STRING_PHRASES:
+            if phrase in lower:
+                error(
+                    errors,
+                    f"{path.relative_to(ROOT)}: suspicious overclaiming phrase {phrase!r} found at {string_path}",
+                )
+
+
+def validate_examples(errors: list[str]) -> None:
+    if not EVIDENCE_DIR.exists():
+        error(errors, f"{EVIDENCE_DIR.relative_to(ROOT)}: evidence example directory is missing")
+        return
+
+    all_examples = sorted(EVIDENCE_DIR.glob("*.json"))
+    for path in all_examples:
+        if not path.name.endswith(".example.json"):
+            error(errors, f"{path.relative_to(ROOT)}: evidence examples must use .example.json suffix")
+
+    for filename, scenario_type in EXPECTED_EXAMPLES.items():
+        path = EVIDENCE_DIR / filename
+        if not path.exists():
+            error(errors, f"{path.relative_to(ROOT)}: expected evidence example is missing")
+            continue
+
+        data = load_json(path, errors)
+        if data is None:
+            continue
+        if not isinstance(data, dict):
+            error(errors, f"{path.relative_to(ROOT)}: top-level JSON value must be an object")
+            continue
+
+        validate_metadata(path, data, scenario_type, errors)
+        validate_identifier_hygiene(path, data, errors)
+        validate_forbidden_claims(path, data, errors)
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    validate_readme(errors)
+    validate_examples(errors)
+
+    if errors:
+        print("ERROR: Evidence example validation failed:")
+        for item in errors:
+            print(f"- {item}")
+        return 1
+
+    print("Evidence example validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a dedicated evidence example hygiene validator for #290.

This PR keeps the existing JSON syntax validator separate and adds `tools/validate_evidence_examples.py` for active evidence example hygiene checks.

The validator checks:

- `examples/evidence/README.md` claim-boundary coverage
- expected permitted-action and non-execution example presence
- `.example.json` naming
- illustrative `example_metadata`
- scenario type
- non-normative status
- schema / implementation / evidence sufficiency non-assertion metadata
- claim-boundary booleans
- selected identifier hygiene
- selected internal identifier consistency
- suspicious overclaiming phrases

## Added

- `tools/validate_evidence_examples.py`

## Updated

- `.github/workflows/validate-aaef-artifacts.yml`
- `examples/evidence/README.md`
- `examples/evidence/permitted-action-evidence.example.json`
- `examples/evidence/non-execution-evidence.example.json`

## Validation behavior

The validator is intentionally described as evidence example hygiene validation.

It does not assert:

- active evidence schema conformance
- implementation conformance
- production readiness
- audit sufficiency
- legal sufficiency
- compliance
- certification
- conformity
- external-framework equivalence

The non-execution example allows `null` identifiers for components that were not invoked, such as backend verification. Internal correlation identifiers are still checked for consistency where present.

## Validation

- `py tools/validate_evidence_examples.py`
- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_external_mappings.py`

## Related

- Contributes to #290
- Related to #311
- Related to #293
- Milestone: `v0.6.0 Planning`
