### PR TITLE
Add post-v0.7.0 version status and baseline reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ Documents under `docs/en/30-54` are v0.5.0 planning materials. They are non-norm
 
 These documents currently remain under `docs/en/` for public review continuity. A future release may move them into a dedicated planning directory if the repository structure is reorganized.
 
+
+### Version status and baseline reference
+
+AAEF uses different "latest" references depending on review purpose.
+
+- Latest completed planning roadmap: v0.7.0.
+- Latest v0.7.0 roadmap wrap-up artifact: `docs/en/status/v070-roadmap-wrap-up-and-release-readiness-note.md`.
+- Current active control and assessment baseline: not changed automatically by v0.7.0.
+- Future v1.0.0 path: not current, active, or baseline until a later release explicitly makes that change.
+
+For the post-v0.7.0 reference rules, see [`docs/en/status/post-v070-version-status-and-baseline-reference-note.md`](docs/en/status/post-v070-version-status-and-baseline-reference-note.md).
+
 ## Repository Structure
 
 ```text

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,13 +81,15 @@ AAEF 面向以下读者：
 
 ## 文档状态
 
-**AAEF v0.5.0 Public Review Planning Release** 是最新公开评审 planning release。
+**AAEF v0.7.0 roadmap work** 是最新已完成的 planning roadmap。published release 状态应以 GitHub Releases、tags、release notes 和明确的 release artifacts 为准。
 
-AAEF v0.5.0 是 non-normative planning and design-clarification release。它增加了面向 authority lifecycle、evidence integrity、approval quality 以及 future v0.5.x work 的 planning models 和 incorporation guidance。除非后续版本明确更新 control catalog、evidence schema、assessment artifacts 或 testing procedures，AAEF v0.4.1 仍然是当前 control and assessment baseline。
+AAEF v0.7.0 是 planning and reviewability consolidation milestone。它完成了 Evaluation Readiness、Implementation Reviewability、Research Positioning、Operational Reconstruction 和 Risk-Owner Decision Support tracks。v0.7.0 不会自动改变 active control and assessment baseline；除非后续版本明确更新 control catalog、evidence schema、assessment artifacts、testing procedures 或相关 baseline artifacts，active baseline 仍按明确的 baseline statements 和 release artifacts 判断。
+
+版本状态和 baseline reference 的详细规则见 `docs/en/status/post-v070-version-status-and-baseline-reference-note.md`。
 
 此前的 v0.3.x、v0.2.x、v0.1.x releases 仍可作为 prior public review baselines 参考。
 
-AAEF v0.5.0 包含的主要内容包括：
+作为 historical planning material，AAEF v0.5.0 包含的主要内容包括：
 
 - control catalog versioning and change impact guidance
 - measurable testing procedures and pass criteria
@@ -100,7 +102,7 @@ AAEF v0.5.0 包含的主要内容包括：
 - refined control-specific testing procedure pass criteria
 - updated conservative external framework mappings, including NIST AI RMF / GenAI Profile, ISO/IEC 42001 feasibility, and CSA Agentic Trust Framework mapping
 
-AAEF v0.5.0 是公开评审 planning release。它不是认证机制、正式标准、implementation conformance claim、audit opinion、compliance equivalence，也不声称能够完全缓解所有风险。
+AAEF 的 planning releases 和 roadmap artifacts 不是认证机制、正式标准、implementation conformance claim、audit opinion、compliance equivalence，也不声称能够完全缓解所有风险。
 
 欢迎通过 Issues 和 Pull Requests 提供反馈。
 

--- a/docs/en/55-researcher-overview.md
+++ b/docs/en/55-researcher-overview.md
@@ -12,7 +12,9 @@ This document does not create new control requirements and does not change the c
 
 ## Current Status
 
-AAEF v0.6.0 Practical Adoption Readiness Planning Release is the latest public review planning release.
+The latest completed planning roadmap is v0.7.0. AAEF v0.7.0 completed the Evaluation Readiness, Implementation Reviewability, Research Positioning, Operational Reconstruction, and Risk-Owner Decision Support tracks. Published-release status should be determined from GitHub Releases, tags, release notes, and explicit release artifacts.
+
+For the post-v0.7.0 version status and baseline reference rules, see `docs/en/status/post-v070-version-status-and-baseline-reference-note.md`.
 
 AAEF v0.4.1 remains the current control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, testing procedures, or related normative or assessment artifacts.
 
@@ -223,9 +225,9 @@ For readers focused on cross-agent systems, start with:
 6. `docs/en/58-cross-agent-budget-propagation.md`
 7. the open Cross-Agent and Cross-Domain Authority umbrella issue and related v0.5.x follow-up issues.
 
-## Current v0.5.x Follow-up Areas
+## Historical v0.5.x Follow-up Areas
 
-The active v0.5.x follow-up work includes:
+The v0.5.x follow-up work included:
 
 - principal context degradation testing criteria;
 - capability-scoped cross-agent delegation controls;

--- a/docs/en/document-map.md
+++ b/docs/en/document-map.md
@@ -28,6 +28,8 @@ A document's location or number does not by itself make it normative.
 
 The current baseline is determined by the release notes and explicit baseline statements in the repository.
 
+For post-v0.7.0 version-status and baseline-reference rules, see `docs/en/status/post-v070-version-status-and-baseline-reference-note.md`.
+
 ## Current Baseline and Assessment-Relevant Artifacts
 
 These artifacts are closest to assessment, validation, schema, mapping, or control operation.
@@ -234,6 +236,7 @@ They may be removed, replaced, or archived when the related milestone, follow-up
 | `docs/en/status/v070-risk-owner-decision-package-checklist.md` | v0.7.0 risk-owner decision package checklist | Checklist for Risk-Owner Decision Support packages, covering decision request, reviewed boundary, reconstruction result, evidence, gaps, residual uncertainty, impact, options, owners, claim boundaries, and decision record linkage. |
 | `docs/en/status/v070-risk-owner-decision-matrix.md` | v0.7.0 risk-owner decision matrix | Decision matrix for Risk-Owner Decision Support, covering accept, reject, request-evidence, defer, and escalate paths for scoped residual uncertainty decisions. |
 | `docs/en/status/v070-roadmap-wrap-up-and-release-readiness-note.md` | v0.7.0 roadmap wrap-up and release-readiness note | Wrap-up and release-readiness note for the v0.7.0 roadmap, summarizing completed child tracks, preserved baseline boundaries, public communication posture, and v1.0.0 path considerations. |
+| `docs/en/status/post-v070-version-status-and-baseline-reference-note.md` | post-v0.7.0 version status and baseline reference note | Clarifies latest completed roadmap, published release, active baseline, historical artifact, and future v1.0.0 path wording after v0.7.0 completion. |
 | `docs/en/status/v060-adoption-navigation-integration-planning.md` | v0.6.x adoption navigation integration planning | Plans how v0.6.0 adoption-oriented materials should be discoverable from README, README.ja, document-map, researcher overview, and future adoption entry points while preserving planning and baseline boundaries. |
 | `docs/en/status/v060-operator-runbook-active-guidance-candidate-review.md` | v0.6.x operator runbook active guidance candidate review | Reviews operator runbook planning material for reusable active guidance candidates, organization-specific areas, evidence review expectations, freeze/hold guidance, operational metrics, handoff guidance, and promotion readiness. |
 | `docs/en/status/v060-operator-guidance-placement-and-scope-planning.md` | v0.6.x operator guidance placement and scope planning | Defines the preferred placement and scope for future active operator guidance, including recommended `docs/en/operator-guidance.md` scope, exclusions, handoff guidance, evidence review coverage, and claim boundaries. |

--- a/docs/en/status/README.md
+++ b/docs/en/status/README.md
@@ -37,6 +37,8 @@ This directory should not contain:
 
 Documents in this directory do not change the current AAEF control and assessment baseline.
 
+For post-v0.7.0 version-status and baseline-reference rules, see [`docs/en/status/post-v070-version-status-and-baseline-reference-note.md`](post-v070-version-status-and-baseline-reference-note.md).
+
 Any normative incorporation must be handled through a later PR that explicitly updates the relevant control, testing, evidence, assessment, schema, mapping, or release artifacts.
 
 ## Current Status Documents
@@ -145,6 +147,7 @@ Any normative incorporation must be handled through a later PR that explicitly u
 - [`docs/en/status/v070-risk-owner-decision-package-checklist.md`](v070-risk-owner-decision-package-checklist.md) - Checklist for v0.7.0 Risk-Owner Decision Support packages, covering decision request, reviewed boundary, reconstruction result, evidence, gaps, residual uncertainty, impact, options, owners, claim boundaries, and decision record linkage.
 - [`docs/en/status/v070-risk-owner-decision-matrix.md`](v070-risk-owner-decision-matrix.md) - Decision matrix for v0.7.0 Risk-Owner Decision Support, covering accept, reject, request-evidence, defer, and escalate paths for scoped residual uncertainty decisions.
 - [`docs/en/status/v070-roadmap-wrap-up-and-release-readiness-note.md`](v070-roadmap-wrap-up-and-release-readiness-note.md) - Wrap-up and release-readiness note for the v0.7.0 roadmap, summarizing completed child tracks, preserved baseline boundaries, public communication posture, and v1.0.0 path considerations.
+- [`docs/en/status/post-v070-version-status-and-baseline-reference-note.md`](post-v070-version-status-and-baseline-reference-note.md) - Post-v0.7.0 reference note clarifying latest completed roadmap, published release, active baseline, historical artifact, and future v1.0.0 path wording.
 - [`docs/en/status/v060-adoption-navigation-integration-planning.md`](v060-adoption-navigation-integration-planning.md) — v0.6.x adoption navigation integration planning.
 - [`docs/en/status/v060-operator-runbook-active-guidance-candidate-review.md`](v060-operator-runbook-active-guidance-candidate-review.md) — v0.6.x operator runbook active guidance candidate review.
 - [`docs/en/status/v060-operator-guidance-placement-and-scope-planning.md`](v060-operator-guidance-placement-and-scope-planning.md) — v0.6.x operator guidance placement and scope planning.

--- a/docs/en/status/post-v070-version-status-and-baseline-reference-note.md
+++ b/docs/en/status/post-v070-version-status-and-baseline-reference-note.md
@@ -1,0 +1,184 @@
+# Post-v0.7.0 Version Status and Baseline Reference Note
+
+## Purpose
+
+This document clarifies how to read version, latest-status, and baseline references after completion of the v0.7.0 roadmap.
+
+AAEF uses different "latest" references depending on the review purpose.
+
+This note is intended to prevent stale or ambiguous version wording in entry-point documents while preserving historical planning artifacts, release preparation materials, and versioned file names.
+
+This document is explanatory status material only. It does not change the active control and assessment baseline, update the control catalog, update the evidence schema, update assessment artifacts, update testing procedures, publish a release, or create a certification, compliance, audit, legal, implementation-conformance, or external-framework-equivalence claim.
+
+## Summary
+
+As of the completion of v0.7.0 roadmap work:
+
+| Reference purpose | Current reference |
+| --- | --- |
+| Latest completed planning roadmap | v0.7.0 |
+| Latest v0.7.0 roadmap wrap-up artifact | `docs/en/status/v070-roadmap-wrap-up-and-release-readiness-note.md` |
+| Latest completed v0.7.0 child tracks | #319, #320, #321, #322, and #323 |
+| Latest published planning release | Determined by GitHub Releases / tags; v0.7.0 roadmap completion does not by itself create a new published release. |
+| Current active control and assessment baseline | Not changed by v0.7.0. It changes only when a later release explicitly updates the control catalog, evidence schema, assessment artifacts, testing procedures, or related baseline artifacts. |
+| Future v1.0.0 path | Not current, not active, and not a baseline yet. It should be handled through separate roadmap or release-planning work. |
+
+## Why "latest" must be qualified
+
+AAEF has several kinds of versioned materials:
+
+- public review baselines,
+- planning releases,
+- planning roadmaps,
+- status and coordination artifacts,
+- release preparation checklists,
+- assessment artifacts,
+- schema artifacts,
+- examples,
+- validators,
+- mapping artifacts, and
+- historical design notes.
+
+A statement that something is "latest" should clarify what kind of latest status it means.
+
+For example:
+
+- "latest completed planning roadmap" is not the same as "latest published GitHub Release";
+- "latest planning artifact" is not the same as "active control and assessment baseline";
+- "latest reviewability material" is not the same as "normative control requirement";
+- "future v1.0.0 path" is not the same as "current baseline."
+
+## Current recommended wording
+
+Use this wording when a document needs to summarize current state:
+
+> The latest completed planning roadmap is v0.7.0.
+>
+> v0.7.0 completed the Evaluation Readiness, Implementation Reviewability, Research Positioning, Operational Reconstruction, and Risk-Owner Decision Support tracks.
+>
+> v0.7.0 does not automatically change the active control and assessment baseline.
+>
+> The active baseline changes only when a later release explicitly updates the control catalog, evidence schema, assessment artifacts, testing procedures, or related baseline artifacts.
+
+Use this wording when distinguishing roadmap completion from release publication:
+
+> v0.7.0 roadmap work has been completed, but roadmap completion is not the same as publishing a new release.
+>
+> Published-release status should be determined by GitHub Releases, tags, release notes, and explicit release artifacts.
+
+Use this wording when discussing v1.0.0:
+
+> Future v1.0.0 path planning should decide whether and how to update the active baseline, control catalog, evidence schema, assessment artifacts, examples, validators, adoption guidance, and public communication posture.
+>
+> v1.0.0 should not be described as current, active, or baseline until a later release explicitly makes that change.
+
+## Historical artifact handling
+
+Versioned historical artifact names should generally remain unchanged.
+
+Examples include:
+
+- `v050x-*` status files,
+- `v060-*` planning files,
+- `v070-*` planning and wrap-up files,
+- release preparation checklists,
+- older planning overview files,
+- prior public review draft references, and
+- historical release notes or citation examples.
+
+These names describe when and why the artifact was created.
+
+They should not be bulk-renamed merely because a later roadmap completed.
+
+## When to update old wording
+
+Old wording should be updated when it makes a current-state claim that is no longer accurate or is likely to confuse readers.
+
+Examples of wording that should be reviewed:
+
+- "latest public review planning release",
+- "current planning milestone",
+- "current roadmap",
+- "active follow-up work",
+- "current status",
+- "current baseline",
+- "remains current",
+- "latest release",
+- "current public review draft", and
+- "latest planning release."
+
+These phrases are safe only when their reference purpose is clear.
+
+## Entry-point document expectations
+
+Entry-point documents should point readers to this note or an equivalent current status reference when they mention version status.
+
+Entry-point documents include:
+
+- `README.md`,
+- localized README files,
+- `docs/en/document-map.md`,
+- `docs/en/status/README.md`,
+- `docs/en/55-researcher-overview.md`, and
+- other overview or adoption entry points.
+
+They do not need to repeat every historical version detail.
+
+## Active baseline boundary
+
+v0.7.0 does not change the active control and assessment baseline by itself.
+
+Planning, reviewability, reconstruction, and decision-support artifacts may be newer than the active baseline, but they do not automatically replace it.
+
+A baseline change should be explicit and should identify which artifacts are updated, such as:
+
+- control catalog,
+- evidence schema,
+- assessment worksheet,
+- assessment profiles,
+- testing procedures,
+- examples,
+- validators,
+- mappings, or
+- release notes.
+
+## Public communication posture
+
+Public communication should avoid presenting v0.7.0 as:
+
+- a new certification scheme,
+- a compliance claim,
+- a legal sufficiency claim,
+- an audit sufficiency claim,
+- an operational readiness claim,
+- a production readiness claim,
+- an implementation conformance claim,
+- an empirical validation claim,
+- an external-framework equivalence claim, or
+- an active baseline replacement.
+
+The safer public posture is:
+
+- v0.7.0 completed major planning and reviewability roadmap work;
+- v0.7.0 clarified evaluation readiness, implementation reviewability, research positioning, operational reconstruction, and risk-owner decision support;
+- v0.7.0 preserved the active baseline boundary; and
+- future v1.0.0 path planning should determine what, if anything, is promoted into a stable baseline.
+
+## Review questions
+
+Reviewers should be able to answer:
+
+- Does the document distinguish latest completed roadmap from latest published release?
+- Does the document distinguish planning material from active baseline?
+- Does the document avoid implying that v0.7.0 updates the control catalog, schema, assessment artifacts, or testing procedures?
+- Does the document avoid implying that v1.0.0 is already current or active?
+- Does the document preserve historical versioned artifact names where they are descriptive?
+- Does the document update or qualify current-state claims that could mislead readers?
+
+## Scope reminder
+
+This note is status and reference material only.
+
+It does not update the active control and assessment baseline, control catalog, evidence schema, assessment artifacts, testing procedures, executable validators, executable prototypes, scenario fixtures, JSON examples, release tags, or GitHub Releases.
+
+It does not establish operational readiness, production readiness, implementation conformance, empirical validation, certification, compliance, conformity, audit sufficiency, legal sufficiency, automated risk acceptance, or external-framework equivalence.


### PR DESCRIPTION
Summary:
- Added `docs/en/status/post-v070-version-status-and-baseline-reference-note.md`.
- Clarified post-v0.7.0 distinctions among latest completed planning roadmap, published release status, active baseline, historical artifacts, and future v1.0.0 path wording.
- Added entry-point references from README, status README, document map, and researcher overview.
- Updated README.zh-CN wording so it no longer presents v0.5.0 as the latest public review planning release.
- Updated researcher overview wording so it no longer presents v0.6.0 as the latest completed planning roadmap.
- Preserved historical v0.5.x / v0.6.x / v0.7.0 artifact names and planning context.

Scope:
- Version-status and baseline-reference clarification only.
- Does not change the active control and assessment baseline.
- Does not update the control catalog, evidence schema, assessment artifacts, or testing procedures.
- Does not add executable validators, executable prototypes, scenario fixtures, or JSON examples.
- Does not publish a release or create a tag.
- Does not claim operational readiness, production readiness, implementation conformance, empirical validation, certification, compliance, conformity, audit sufficiency, legal sufficiency, or external-framework equivalence.

Validation:
- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`

Related:
- Follows completion of v0.7.0 roadmap #317.
- Prepares for separate v1.0.0 path planning.
