### PR TITLE
Add post-v1.0.0 README version baseline status note

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,11 @@
 
 [![Validate AAEF Artifacts](https://github.com/mkz0010/agentic-authority-evidence-framework/actions/workflows/validate-aaef-artifacts.yml/badge.svg)](https://github.com/mkz0010/agentic-authority-evidence-framework/actions/workflows/validate-aaef-artifacts.yml)
 
+<!-- AAEF_VERSION_BASELINE_STATUS_START -->
+> [!NOTE]
+> **バージョン / ベースライン状態:** 最新リリースは [AAEF v1.0.0](https://github.com/mkz0010/agentic-authority-evidence-framework/releases/tag/v1.0.0) です。AAEF v1.0.0 は conservative release path planning release であり、active control and assessment baseline は変更しません。また、certification、compliance、conformity、audit/legal sufficiency、implementation conformance、production readiness、external-framework equivalence を主張しません。
+<!-- AAEF_VERSION_BASELINE_STATUS_END -->
+
 **AAEF: Agentic AI SystemsのためのAction Assurance Control Profile**
 
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Validate AAEF Artifacts](https://github.com/mkz0010/agentic-authority-evidence-framework/actions/workflows/validate-aaef-artifacts.yml/badge.svg)](https://github.com/mkz0010/agentic-authority-evidence-framework/actions/workflows/validate-aaef-artifacts.yml)
 
+<!-- AAEF_VERSION_BASELINE_STATUS_START -->
+> [!NOTE]
+> **Version / baseline status:** Latest release: [AAEF v1.0.0](https://github.com/mkz0010/agentic-authority-evidence-framework/releases/tag/v1.0.0). AAEF v1.0.0 is a conservative release path planning release. It does not change the active control and assessment baseline, and it does not establish certification, compliance, conformity, audit sufficiency, legal sufficiency, implementation conformance, production readiness, or external-framework equivalence.
+<!-- AAEF_VERSION_BASELINE_STATUS_END -->
+
 **AAEF: An Action Assurance Control Profile for Agentic AI Systems**
 
 Agentic Authority & Evidence Framework (AAEF) is a practical control framework for governing **delegated authority**, **policy-enforced action boundaries**, and **verifiable evidence** in agentic AI systems.


### PR DESCRIPTION
Summary:
- Added a narrow version / baseline status note to the README entrypoint.
- Clarified that the latest release is AAEF v1.0.0.
- Clarified that AAEF v1.0.0 is a conservative release path planning release.
- Clarified that AAEF v1.0.0 does not change the active control and assessment baseline.
- Clarified that AAEF v1.0.0 does not establish certification, compliance, conformity, audit sufficiency, legal sufficiency, implementation conformance, production readiness, or external-framework equivalence.
- Kept the change narrow and avoided broader README restructuring.

Scope:
- Post-v1.0.0 public entrypoint clarification only.
- Does not publish a new release.
- Does not change the active control and assessment baseline.
- Does not update the control catalog, control IDs, evidence schema, assessment artifacts, or testing procedures.
- Does not add executable validators, executable prototypes, scenario fixtures, or JSON examples.
- Does not update citation status.
- Does not approve public announcement text.
- Does not claim implementation readiness, adoption readiness, operational readiness, production readiness, implementation conformance, assessment sufficiency, testing sufficiency, evidence sufficiency, semantic correctness, empirical validation, peer-reviewed acceptance, certification, compliance, conformity, audit sufficiency, legal sufficiency, automated risk acceptance, control conformance, or external-framework equivalence.

Validation:
- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`

Related:
- Supports #388.
- Follows `docs/en/status/post-v100-public-communication-and-readme-review.md`.
