### PR TITLE
Update post-v1.0.0 README version status baseline reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,14 @@ These documents currently remain under `docs/en/` for public review continuity. 
 
 ### Version status and baseline reference
 
-AAEF uses different "latest" references depending on review purpose.
+- Latest release: [AAEF v1.0.0](https://github.com/mkz0010/agentic-authority-evidence-framework/releases/tag/v1.0.0).
+- Release posture: conservative release path planning release.
+- Current active control and assessment baseline: unchanged by v1.0.0.
+- Active baseline reference: AAEF v0.4.1 remains the current active control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, or testing procedures.
+- Planning and readiness-review materials from v0.6.0, v0.7.0, and v1.0.0 are status and planning records unless a later release explicitly promotes their contents into the active baseline.
+- AAEF v1.0.0 does not establish certification, compliance, conformity, audit sufficiency, legal sufficiency, implementation conformance, production readiness, or external-framework equivalence.
 
-- Latest completed planning roadmap: v0.7.0.
-- Latest v0.7.0 roadmap wrap-up artifact: `docs/en/status/v070-roadmap-wrap-up-and-release-readiness-note.md`.
-- Current active control and assessment baseline: not changed automatically by v0.7.0.
-- Future v1.0.0 path: not current, active, or baseline until a later release explicitly makes that change.
-
-For the post-v0.7.0 reference rules, see [`docs/en/status/post-v070-version-status-and-baseline-reference-note.md`](docs/en/status/post-v070-version-status-and-baseline-reference-note.md).
+For the post-v1.0.0 release and baseline posture, see the v1.0.0 release notes and the post-v1.0.0 review materials under `docs/en/status/`.
 
 ## Repository Structure
 


### PR DESCRIPTION
Summary:
- Updated the README version status and baseline reference section for the post-v1.0.0 state.
- Clarified that the latest release is AAEF v1.0.0.
- Clarified that AAEF v1.0.0 is a conservative release path planning release.
- Clarified that AAEF v1.0.0 does not change the active control and assessment baseline.
- Clarified that the active control and assessment baseline remains AAEF v0.4.1 unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, or testing procedures.
- Replaced stale future-facing v1.0.0 wording with current post-v1.0.0 wording.
- Preserved conservative claim boundaries.

Scope:
- Post-v1.0.0 README consistency update only.
- Does not publish a new release.
- Does not change the active control and assessment baseline.
- Does not update the control catalog, control IDs, evidence schema, assessment artifacts, or testing procedures.
- Does not add executable validators, executable prototypes, scenario fixtures, or JSON examples.
- Does not update citation status.
- Does not approve public announcement text.
- Does not claim implementation readiness, adoption readiness, operational readiness, production readiness, implementation conformance, assessment sufficiency, testing sufficiency, evidence sufficiency, semantic correctness, empirical validation, peer-reviewed acceptance, certification, compliance, conformity, audit sufficiency, legal sufficiency, automated risk acceptance, control conformance, or external-framework equivalence.

Validation:
- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`

Related:
- Supports #388.
- Addresses external review finding B-2: stale README version status and baseline reference wording after v1.0.0 publication.
