### PR TITLE
Update README public communication positioning

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,14 @@
 
 **AAEF: Agentic AI SystemsのためのAction Assurance Control Profile**
 
+Agentic Authority & Evidence Framework（AAEF）は、Agentic AI Systems における行為の権限境界を記述し、レビューし、証跡化するための公開フレームワークです。
+
+中心となる考え方は次のとおりです。
+
+> Model output is not authority.
+
+AAEF は、モデル出力、エージェントが生成した意図、またはツール要求が、実際の行為へ移る境界に焦点を当てます。その行為が認可され、強制され、境界づけられ、帰属可能で、証跡によって検証可能かを問います。
+
 
 ## 採用準備向けナビゲーション
 
@@ -63,9 +71,11 @@ AAEFは、組織が以下の5つの問いに答えられるようにすること
 
 AAEFは、新しいIDプロトコル、認証プロトコル、認可プロトコル、またはエージェント通信プロトコルを定義するものではありません。
 
-AAEFは、AIガバナンスフレームワーク、Zero Trustフレームワーク、アイデンティティ標準、エージェント通信標準、脅威分類を置き換えるものでもありません。
+AAEFは、AIガバナンスフレームワーク、Zero Trustフレームワーク、アイデンティティ標準、エージェント通信標準、特権アクセス管理、監査プログラム、法務レビュー、脅威分類を置き換えるものでもありません。
 
-AAEFは、高影響なAIエージェントの行為に対するAction Assurance Controlを定義することで、これらを補完することを目的としています。
+AAEFは、認証制度、コンプライアンスフレームワーク、監査意見、法的十分性モデル、本番準備完了の主張、または外部フレームワークとの同等性主張ではありません。
+
+AAEFは、高影響なAIエージェントの行為に対するAction Assurance Controlを定義することで、既存のガバナンス、セキュリティ、アイデンティティ、保証の取り組みを補完することを目的としています。
 
 ## 言語 / 翻訳
 
@@ -95,13 +105,15 @@ AAEFは、主に以下の読者を想定しています。
 
 ## ドキュメントの状態
 
-**AAEF v0.6.0 Practical Adoption Readiness Planning Release** が最新の公開レビュー planning release です。
+**AAEF v1.0.0 Stable Release Path Planning Release** が最新リリースです。
 
-AAEF v0.6.0 は、non-normative な planning and adoption-readiness release です。implementer、operational、legal/compliance、security architecture、および risk owner 向けの planning artifacts を、将来の adoption-facing refinement に向けて整理しています。
+AAEF v1.0.0 は conservative release path planning release です。リリース経路と post-v1.0.0 の planning posture を整理しますが、それ自体では current active control and assessment baseline を変更しません。
 
-AAEF v0.6.0 は、それ自体では current active control and assessment baseline を変更しません。control catalog、evidence schema、assessment artifacts、または testing procedures が後続リリースで明示的に更新されるまでは、**AAEF v0.4.1 が現在の control and assessment baseline** として維持されます。
+control catalog、evidence schema、assessment artifacts、または testing procedures が後続リリースで明示的に更新されるまでは、**AAEF v0.4.1 が現在の control and assessment baseline** として維持されます。
 
-AAEF v0.5.0 は prior public review planning release として引き続き参照できます。以前の v0.3.x、v0.2.x、v0.1.x releases は prior public review baselines として引き続き参照できます。
+v0.6.0、v0.7.0、v1.0.0、および post-v1.0.0 status review の planning / readiness-review materials は、後続リリースで明示的に active baseline へ昇格されない限り、status and planning records です。
+
+以前の v0.6.0、v0.5.0、v0.4.x、v0.3.x、v0.2.x、v0.1.x releases は、それぞれの release posture に応じて、過去の public review、planning、または baseline-related records として参照できます。
 
 AAEF v0.6.0 に含まれる主な要素:
 
@@ -122,7 +134,9 @@ AAEF v0.6.0 に含まれる主な要素:
 - external framework mapping CSV enrichment review
 - release preparation planning, release notes draft, release readiness review, and release decision record
 
-AAEF v0.6.0 は公開レビュー planning release です。認証制度、正式標準、implementation conformance claim、audit opinion、compliance equivalence、conformity claim、または完全なリスク軽減を主張するものではありません。
+AAEF v1.0.0 は、certification、compliance、conformity、audit sufficiency、legal sufficiency、implementation conformance、production readiness、または external-framework equivalence を主張しません。
+
+AAEF artifacts は structured review を支援し得ますが、implementation-specific assessment、組織ごとの risk decision、legal review、external assurance process、または auditor judgment を置き換えるものではありません。
 
 フィードバック、Issue、Pull Requestを歓迎します。
 
@@ -142,7 +156,7 @@ AAEFを初めて読む場合は、英語版の以下の文書から読むこと�
 
 この成果物を参照する場合は、以下のように引用してください。
 
-> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.6.0 Practical Adoption Readiness Planning Release, 2026.
+> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v1.0.0 Stable Release Path Planning Release, 2026.
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@
 
 **AAEF: An Action Assurance Control Profile for Agentic AI Systems**
 
-Agentic Authority & Evidence Framework (AAEF) is a practical control framework for governing **delegated authority**, **policy-enforced action boundaries**, and **verifiable evidence** in agentic AI systems.
+Agentic Authority & Evidence Framework (AAEF) is a public framework for describing, reviewing, and evidencing authority boundaries in agentic AI systems.
+
+Its core thesis is:
+
+> Model output is not authority.
+
+AAEF focuses on the point where model output, agent-generated intent, or tool requests may become real-world action. It asks whether that action was authorized, enforced, bounded, attributable, and evidenced.
 
 AAEF is designed for AI agents that do more than generate text. It focuses on agents that can call tools, access data, delegate tasks, interact with other agents, and perform meaningful actions on behalf of humans or organizations.
 
@@ -50,9 +56,11 @@ If an organization cannot answer these questions, it cannot reliably govern agen
 
 AAEF does **not** define a new identity protocol, authentication protocol, authorization protocol, or agent communication protocol.
 
-AAEF does **not** replace AI governance frameworks, Zero Trust frameworks, identity standards, agent communication standards, or threat taxonomies.
+AAEF does **not** replace AI governance frameworks, Zero Trust frameworks, identity standards, agent communication standards, privileged-access controls, audit programs, legal review, or threat taxonomies.
 
-Instead, AAEF is intended to complement them by defining action assurance controls for high-impact AI agent actions.
+AAEF is not a certification scheme, compliance framework, audit opinion, legal sufficiency model, production-readiness claim, or assertion of equivalence with external frameworks.
+
+Instead, AAEF is intended to complement existing governance, security, identity, and assurance approaches by defining action assurance controls for high-impact AI agent actions.
 
 ## Language / Translations
 
@@ -95,13 +103,15 @@ AAEF is intended for:
 
 ## Document Status
 
-**AAEF v0.6.0 Practical Adoption Readiness Planning Release** is the latest public review planning release.
+**AAEF v1.0.0 Stable Release Path Planning Release** is the latest release.
 
-AAEF v0.6.0 is a non-normative planning and adoption-readiness release. It organizes implementer, operational, legal/compliance, security architecture, and risk owner planning artifacts for future adoption-facing refinement.
+AAEF v1.0.0 is a conservative release path planning release. It consolidates the release path and post-v1.0.0 planning posture, but it does not, by itself, change the current active control and assessment baseline.
 
-AAEF v0.6.0 does not, by itself, change the current active control and assessment baseline. AAEF v0.4.1 remains the current control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, or testing procedures.
+AAEF v0.4.1 remains the current active control and assessment baseline unless a later release explicitly updates the control catalog, evidence schema, assessment artifacts, or testing procedures.
 
-AAEF v0.5.0 remains available as the prior public review planning release. Earlier v0.3.x, v0.2.x, and v0.1.x releases remain available as prior public review baselines.
+Planning and readiness-review materials from v0.6.0, v0.7.0, v1.0.0, and post-v1.0.0 status reviews remain status and planning records unless a later release explicitly promotes their contents into the active baseline.
+
+Earlier v0.6.0, v0.5.0, v0.4.x, v0.3.x, v0.2.x, and v0.1.x releases remain available as prior public review, planning, or baseline-related records according to their release posture.
 
 The current control catalog file remains:
 
@@ -136,7 +146,9 @@ The v0.4.x Public Review Draft includes:
 - validation for testing procedures and external mappings,
 - and historical release preparation records under `docs/en/release/`.
 
-AAEF v0.6.0 remains a public review planning release. It is not a certification scheme, formal standard, implementation conformance claim, audit opinion, compliance equivalence, conformity claim, or claim of complete mitigation.
+AAEF v1.0.0 does not establish certification, compliance, conformity, audit sufficiency, legal sufficiency, implementation conformance, production readiness, or external-framework equivalence.
+
+AAEF artifacts may support structured review, but they do not replace implementation-specific assessment, organizational risk decisions, legal review, external assurance processes, or auditor judgment.
 
 Feedback, issues, and pull requests are welcome.
 
@@ -384,7 +396,7 @@ For the post-v1.0.0 release and baseline posture, see the v1.0.0 release notes a
 
 If you reference this work, please cite it as:
 
-> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v0.6.0 Practical Adoption Readiness Planning Release, 2026.
+> Kazuma Horishita, *Agentic Authority & Evidence Framework (AAEF): An Action Assurance Control Profile for Agentic AI Systems*, v1.0.0 Stable Release Path Planning Release, 2026.
 
 ## Research and Open Questions
 


### PR DESCRIPTION
## Summary

- Updated README public-facing positioning after the post-v1.0.0 public communication refinement review.
- Updated README.ja reference translation positioning to match the English README posture.
- Clarified AAEF's public framing around authority boundaries, action execution, and the core thesis "Model output is not authority."
- Updated stale v0.6.0 latest-release wording in the README and README.ja document status sections.
- Updated citation wording from v0.6.0 to v1.0.0 release posture.
- Preserved the active-baseline boundary: AAEF v0.4.1 remains the active control and assessment baseline unless a later release explicitly updates baseline artifacts.
- Clarified that AAEF is not a certification scheme, compliance framework, audit opinion, legal sufficiency model, production-readiness claim, or external-framework equivalence claim.

## Scope

This PR updates public-entrypoint wording only.

It does not:

- update the active baseline
- create a v1.1.0 roadmap
- update the control catalog
- update the evidence schema
- update assessment artifacts
- update testing procedures
- update validators
- update examples or fixtures
- create or update external mappings
- promote any material into the active baseline
- establish implementation readiness
- establish operational readiness
- establish production readiness
- establish implementation conformance
- establish control conformance
- establish evidence sufficiency
- establish assessment sufficiency
- establish audit or legal sufficiency
- establish certification, compliance, conformity, or external-framework equivalence
- establish semantic correctness or empirical validation
- establish automated risk acceptance

## Validation

- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`

## Related

- Tracks #403
- Follows #404
