### PR TITLE
Broaden minimal use guide action decision wording

### DIFF
--- a/docs/en/minimal-use-guide.md
+++ b/docs/en/minimal-use-guide.md
@@ -336,13 +336,13 @@ This table is only a discussion aid.
 
 It is not a complete AAEF assessment result.
 
-## Other tool-call decisions where the same pattern applies
+## Other AI agent action decisions where the same pattern applies
 
 The email example is only one illustration.
 
-The same AAEF review pattern can apply to other AI agent tool-call decisions.
+The same AAEF review pattern can apply to other AI agent action decisions, including tool calls, backend operations, data access, external communications, and delegated tasks.
 
-| Tool-call decision | What the review should bound | What evidence or non-execution record should show |
+| Action decision | What the review should bound | What evidence or non-execution record should show |
 | --- | --- | --- |
 | Create, modify, or delete a cloud resource | Resource identity, cloud account, environment, requested change, cost or security impact, and authority to change it. | Linked request, policy or approval decision, dispatch result, backend result, rollback record, or non-dispatch reason. |
 | Query or export data from an internal database | Dataset, query scope, row or field limits, purpose, sensitivity, retention, and principal context. | Query request, authorization decision, export or query result, data boundary, approval context, or blocked/out-of-scope reason. |


### PR DESCRIPTION
## Summary

- Broadened wording in `docs/en/minimal-use-guide.md` so AAEF is not misread as applying only to tool-call decisions.
- Updated the breadth section heading from tool-call decisions to AI agent action decisions.
- Updated the introductory sentence to mention tool calls, backend operations, data access, external communications, and delegated tasks.
- Updated the table first-column heading from `Tool-call decision` to `Action decision`.
- Preserved the existing examples, non-normative posture, and claim-boundary language.

## Scope

This PR is a limited post-v1.0.0 follow-up wording refinement.

It does not:

- add new examples
- add detailed scenarios
- replace the existing email example
- rewrite the guide
- restructure the guide
- remove claim-boundary reminders
- add a new status artifact
- update README
- update `docs/en/document-map.md`
- update the active baseline
- create a v1.1.0 roadmap
- open an active-baseline candidate review
- update the control catalog
- update the evidence schema
- update assessment artifacts
- update testing procedures
- update validators
- create a certification scheme
- create an audit opinion model
- claim legal sufficiency
- claim audit sufficiency
- claim compliance sufficiency
- claim evidence sufficiency
- claim assessment sufficiency
- claim production readiness
- claim implementation conformance
- claim control conformance
- claim external-framework equivalence
- claim that minimal AAEF use constitutes a full AAEF assessment
- incorporate AAEF-AI-VA technical implementation details
- incorporate patent-sensitive implementation concepts
- incorporate AI Compute Credit concepts
- incorporate token authority propositions
- approve commercial positioning
- authorize live security scanning
- authorize third-party target testing
- describe exploit execution
- describe credential use by AI
- describe destructive production operations

## Validation

- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`

## Related

- Tracks #419
- Follows #418
