### PR TITLE
Normalize minimal use guide action decision wording

### DIFF
--- a/docs/en/minimal-use-guide.md
+++ b/docs/en/minimal-use-guide.md
@@ -170,7 +170,7 @@ A reviewer should not assume that a human approval click is the same as risk-own
 
 ## One action-flow review pattern
 
-This pattern illustrates AAEF framing for one AI agent tool-call decision.
+This pattern illustrates AAEF framing for one AI agent action decision.
 
 It is not a complete assessment procedure.
 


### PR DESCRIPTION
## Summary

- Replaced one remaining narrow wording instance in `docs/en/minimal-use-guide.md`.
- Changed the action-flow pattern introduction from `AI agent tool-call decision` to `AI agent action decision`.
- Preserved the existing examples, non-normative posture, and claim-boundary language.

## Scope

This PR is a limited post-v1.0.0 wording cleanup.

It does not:

- add new examples
- add detailed scenarios
- replace the existing email example
- rewrite the guide
- restructure the guide
- remove claim-boundary reminders
- add a new status artifact
- update README
- update `docs/en/document-map.md`
- update the active baseline
- create a v1.1.0 roadmap
- open an active-baseline candidate review
- update the control catalog
- update the evidence schema
- update assessment artifacts
- update testing procedures
- update validators
- create a certification scheme
- create an audit opinion model
- claim legal sufficiency
- claim audit sufficiency
- claim compliance sufficiency
- claim evidence sufficiency
- claim assessment sufficiency
- claim production readiness
- claim implementation conformance
- claim control conformance
- claim external-framework equivalence
- claim that minimal AAEF use constitutes a full AAEF assessment
- incorporate AAEF-AI-VA technical implementation details
- incorporate patent-sensitive implementation concepts
- incorporate AI Compute Credit concepts
- incorporate token authority propositions
- approve commercial positioning
- authorize live security scanning
- authorize third-party target testing
- describe exploit execution
- describe credential use by AI
- describe destructive production operations

## Validation

- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`

## Related

- Tracks #421
- Follows #419
