### PR TITLE
Add operational action reviewer walkthrough

### DIFF
--- a/examples/prototype/fixtures/operational-action/README.md
+++ b/examples/prototype/fixtures/operational-action/README.md
@@ -35,6 +35,8 @@ Start with `action-request.example.json`, then follow the identifiers through `a
 
 The point is not to model logistics operations. The point is to see where proposal, authority, dispatch, backend invocation or non-invocation, evidence, and reconstruction are separated.
 
+For a longer static reviewer walkthrough, see [`reviewer-walkthrough.md`](reviewer-walkthrough.md).
+
 ## Review questions
 
 A reviewer should be able to ask:

--- a/examples/prototype/fixtures/operational-action/reviewer-walkthrough.md
+++ b/examples/prototype/fixtures/operational-action/reviewer-walkthrough.md
@@ -1,0 +1,241 @@
+# Operational Action Fixture Reviewer Walkthrough
+
+Status: Static reviewer walkthrough.
+
+This walkthrough explains how to review the static `operational-action/` fixture family.
+
+It is not a logistics process, RPA implementation guide, backend integration guide, deployment guide, conformance test, certification artifact, audit opinion, legal/compliance determination, evidence sufficiency determination, assessment sufficiency determination, production-readiness claim, customer PoC approval, or external-framework equivalence claim.
+
+## Purpose
+
+The purpose of this walkthrough is to help a reviewer follow the static evidence chain for a simulated operational action.
+
+The review question is:
+
+> Can a reviewer reconstruct what was proposed, what authority boundary was checked, whether dispatch occurred, whether a simulated backend was invoked or not invoked, what evidence was recorded, and what remains outside the fixture?
+
+The point is not to decide whether the logistics decision is correct.
+
+The point is to see whether proposal, authority, dispatch, backend invocation or non-invocation, evidence, and reconstruction are separated.
+
+## Fixture family
+
+The fixture family contains three scenario paths:
+
+- `permitted-shipment-release/`
+- `denied-address-change/`
+- `human-review-required-expedited-shipment/`
+
+Each scenario contains the same six record types:
+
+1. `action-request.example.json`
+2. `authorization-decision.example.json`
+3. `dispatch-decision.example.json`
+4. `backend-verification.example.json`
+5. `evidence-event.example.json`
+6. `reconstruction-notes.example.json`
+
+The file names and field shapes are illustrative fixture structure only. They are not a required AAEF schema, conformance format, or production data model.
+
+## Common review sequence
+
+For any scenario, review the files in this order.
+
+### 1. Action request
+
+Open `action-request.example.json`.
+
+Ask:
+
+- What action was requested?
+- Was the proposal source treated as authority?
+- What action type and scenario inputs are shown?
+- Does the record say that authorization is required before execution or dispatch?
+
+Expected AAEF boundary:
+
+- the model or automation proposal is represented as a request
+- the request is not treated as authority
+- execution remains dependent on a separate authorization boundary
+
+### 2. Authorization decision
+
+Open `authorization-decision.example.json`.
+
+Ask:
+
+- What decision was made?
+- Is the decision `allowed`, `denied`, or `human_review_required`?
+- What rationale is recorded?
+- Does the record keep the decision separate from the model or automation proposal?
+
+Expected AAEF boundary:
+
+- authority is decided at the authorization boundary
+- the proposal itself does not authorize execution
+- the recorded rationale is illustrative and not a logistics policy recommendation
+
+### 3. Dispatch decision
+
+Open `dispatch-decision.example.json`.
+
+Ask:
+
+- Was the action dispatched?
+- Does dispatch match the authorization decision?
+- Is a denied or held request prevented from dispatch?
+
+Expected AAEF boundary:
+
+- dispatch is separate from authorization
+- authorization is not collapsed into backend execution
+- denied or held requests can produce reviewable non-execution evidence
+
+### 4. Backend verification or non-invocation
+
+Open `backend-verification.example.json`.
+
+Ask:
+
+- Was the simulated backend invoked?
+- If not invoked, is the non-invocation record explicit?
+- Does the record preserve correlation to the dispatch decision?
+
+Expected AAEF boundary:
+
+- backend invocation or non-invocation is visible
+- this is a simulated backend boundary record
+- it is not a real backend integration or backend implementation pattern
+
+### 5. Evidence event
+
+Open `evidence-event.example.json`.
+
+Ask:
+
+- What outcome was recorded?
+- Does the evidence event link back to the request, authorization decision, dispatch decision, and backend record?
+- Does the record identify non-execution evidence where appropriate?
+
+Expected AAEF boundary:
+
+- evidence supports review and reconstruction
+- evidence does not prove legal sufficiency, audit sufficiency, compliance sufficiency, correctness, production readiness, implementation conformance, or external-framework equivalence
+
+### 6. Reconstruction notes
+
+Open `reconstruction-notes.example.json`.
+
+Ask:
+
+- Can a reviewer reconstruct the action chain?
+- Can the reviewer see what was proposed, decided, dispatched or not dispatched, invoked or not invoked, and evidenced?
+- Are fixture conditions treated as illustrative inputs rather than production controls?
+
+Expected AAEF boundary:
+
+- reconstruction is possible from the static records
+- reviewer judgment is still required
+- the fixture does not become a validator, conformance test, or production implementation
+
+## Scenario-specific reading notes
+
+### Permitted shipment release
+
+Use `permitted-shipment-release/` to review an allowed path.
+
+Expected chain:
+
+- request proposes a shipment hold release
+- authorization decision is `allowed`
+- dispatch decision indicates simulated dispatch
+- backend record indicates simulated invocation and acceptance
+- evidence outcome is `executed`
+- reconstruction notes should make the allowed path reviewable
+
+Review focus:
+
+- allowed action should still be traceable
+- authority should not be inferred from the proposal itself
+- simulated backend invocation should remain clearly non-production
+
+### Denied address change
+
+Use `denied-address-change/` to review a denied non-execution path.
+
+Expected chain:
+
+- request proposes a delivery address change
+- authorization decision is `denied`
+- dispatch decision is `not_dispatched`
+- backend record indicates simulated backend non-invocation
+- evidence outcome is `not_executed`
+- `non_execution_evidence` should be true
+- reconstruction notes should make the denial and non-execution reviewable
+
+Review focus:
+
+- denial should not disappear from evidence
+- non-dispatch should be explicit
+- backend non-invocation should be reviewable
+- the record should not imply a real logistics or fraud policy
+
+### Human-review-required expedited shipment
+
+Use `human-review-required-expedited-shipment/` to review a held path.
+
+Expected chain:
+
+- request proposes expedited shipment
+- authorization decision is `human_review_required`
+- dispatch decision is `not_dispatched_pending_review`
+- backend record indicates simulated backend non-invocation pending review
+- evidence outcome is `pending_human_review`
+- `non_execution_evidence` should be true because automatic execution did not occur
+- reconstruction notes should make the pending state reviewable
+
+Review focus:
+
+- pending review is not final execution approval
+- the fixture records that automatic execution did not occur
+- it does not decide the final result after human review
+- reviewer judgment remains separate from automated dispatch
+
+## Claim-boundary checklist
+
+When reviewing these fixtures, confirm that they do not imply:
+
+- production readiness
+- deployment guidance
+- real logistics processing
+- real RPA integration
+- real backend execution
+- real customer data handling
+- real credential use
+- logistics policy correctness
+- RPA implementation correctness
+- backend implementation correctness
+- AAEF implementation conformance
+- AAEF control conformance
+- certification
+- audit sufficiency
+- legal sufficiency
+- compliance sufficiency
+- evidence sufficiency
+- assessment sufficiency
+- external-framework equivalence
+- scanner behavior
+- vulnerability assessment behavior
+- AAEF-AI-VA implementation disclosure
+
+## Relationship to validation
+
+This walkthrough is not a validator.
+
+It does not replace `tools/validate_prototype_examples.py`.
+
+It does not extend validation coverage.
+
+It only explains how a reviewer can read the static operational-action fixture family.
+
+Any future operational-action validation should remain separately scoped and limited to static structural and consistency checks.


### PR DESCRIPTION
## Summary

- Added `examples/prototype/fixtures/operational-action/reviewer-walkthrough.md`.
- Added a static reviewer walkthrough for the operational-action fixture family.
- Explained the common review sequence across:
  - `action-request.example.json`
  - `authorization-decision.example.json`
  - `dispatch-decision.example.json`
  - `backend-verification.example.json`
  - `evidence-event.example.json`
  - `reconstruction-notes.example.json`
- Added scenario-specific reading notes for:
  - `permitted-shipment-release`
  - `denied-address-change`
  - `human-review-required-expedited-shipment`
- Preserved non-execution and pending-review boundaries.
- Added claim-boundary checklist language.
- Clarified that the walkthrough is not a validator and does not extend validation coverage.
- Linked the walkthrough from `examples/prototype/fixtures/operational-action/README.md`.

## Scope

This PR adds a static reviewer walkthrough only.

It does not:

- update validators
- update JSON fixture records
- update root README
- update `docs/en/document-map.md`
- update `docs/en/status/README.md`
- update `docs/en/status/post-v100-operational-action-boundary-demo-planning.md`
- update `docs/en/status/post-v100-operational-action-validation-planning.md`
- plan or implement a minimal executable proof-of-concept
- add executable code
- add live AI calls
- add external service calls
- add real RPA
- add real logistics processing
- add real shipment processing
- add real address changes
- add real backend execution
- add real credential use
- add real customer data
- add scanner behavior
- add vulnerability assessment behavior
- add exploit execution
- add destructive production operations
- add AAEF-AI-VA implementation details
- add patent-sensitive browser-state or diagnostic reconstruction detail
- add commercial PoC material
- update the active baseline
- create a v1.1.0 roadmap
- open an active-baseline candidate review
- update the control catalog
- update the evidence schema
- update assessment artifacts
- update testing procedures
- create a certification scheme
- create an audit opinion model
- claim legal sufficiency
- claim audit sufficiency
- claim compliance sufficiency
- claim evidence sufficiency
- claim assessment sufficiency
- claim production readiness
- claim implementation conformance
- claim control conformance
- claim external-framework equivalence

## Validation

- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`
- `py tools/validate_prototype_examples.py`

## Related

- Tracks #437
- Follows #436
