### PR TITLE
Clarify evidence reconstruction wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ AAEF focuses on five practical assurance questions:
 2. **On whose behalf did it act?**
 3. **What authority did it have?**
 4. **Was the action allowed at the point of execution?**
-5. **What evidence proves what happened?**
+5. **What evidence supports review and reconstruction of the action path?**
 
 If an organization cannot answer these questions, it cannot reliably govern agentic AI systems in production.
 

--- a/docs/en/00-introduction.md
+++ b/docs/en/00-introduction.md
@@ -44,7 +44,7 @@ AAEF helps organizations answer five questions:
 2. **On whose behalf did it act?**
 3. **What authority did it have?**
 4. **Was the action allowed at the point of execution?**
-5. **What evidence proves what happened?**
+5. **What evidence supports review and reconstruction of the action path?**
 
 If an organization cannot answer these questions, it cannot reliably govern agentic AI in production.
 

--- a/docs/en/14-evidence-event-schema.md
+++ b/docs/en/14-evidence-event-schema.md
@@ -26,7 +26,7 @@ The evidence event schema provides a structured way to record high-impact agenti
 2. On whose behalf did it act?
 3. What authority did it have?
 4. Was the action allowed at the point of execution?
-5. What evidence proves what happened?
+5. What evidence supports review and reconstruction of the action path?
 
 The schema is designed to support:
 


### PR DESCRIPTION
## Summary

- Replaced stronger “evidence proves what happened” wording with safer “evidence supports review and reconstruction of the action path” wording.
- Aligned public-entry and foundational wording with existing evidence non-proof boundaries.
- Preserved the distinction that AAEF evidence supports review and reconstruction but does not prove correctness, legal sufficiency, audit sufficiency, compliance sufficiency, production readiness, implementation conformance, or external-framework equivalence.

## Scope

This PR is a narrow wording cleanup following the open design question around action assurance, static policy, evidence chain composition, and scoped attestation freshness.

It does not:

- update the active baseline
- update framework version
- update `CITATION.cff`
- update `CHANGELOG.md`
- update validators
- update JSON fixture records
- update schemas
- update controls
- update assessment artifacts
- update testing procedures
- introduce scoped attestation freshness as a main AAEF concept
- add new evidence schema fields
- add validator behavior
- add executable code
- add live AI calls
- add external service calls
- add real RPA
- add real logistics processing
- add real shipment processing
- add real address changes
- add real backend execution
- add real credential use
- add real customer data
- add scanner behavior
- add vulnerability assessment behavior
- add exploit execution
- add destructive production operations
- add AAEF-AI-VA implementation details
- add patent-sensitive browser-state or diagnostic reconstruction detail
- add commercial PoC material
- create a v1.1.0 roadmap
- open an active-baseline candidate review
- create a certification scheme
- create an audit opinion model
- claim legal sufficiency
- claim audit sufficiency
- claim compliance sufficiency
- claim evidence sufficiency
- claim assessment sufficiency
- claim production readiness
- claim implementation conformance
- claim control conformance
- claim external-framework equivalence

## Validation

- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`
- `py tools/validate_prototype_examples.py`

## Related

- Addresses part of #412
- Follows post-v1.0.0 operational-action and evidence-boundary review work
