### PR TITLE
Clean remaining evidence proof wording

### DIFF
--- a/docs/en/status/post-v100-framework-gap-statement-planning.md
+++ b/docs/en/status/post-v100-framework-gap-statement-planning.md
@@ -30,7 +30,7 @@ AAEF is most relevant when a system must answer:
 2. On whose behalf was the action requested?
 3. With what authority?
 4. Was the action allowed at the point of execution?
-5. What evidence proves what happened or did not happen?
+5. What evidence supports review and reconstruction of what happened or did not happen?
 
 ## Planning-level gap statement
 

--- a/docs/en/status/v060-research-positioning-review.md
+++ b/docs/en/status/v060-research-positioning-review.md
@@ -37,7 +37,7 @@ A production system must also answer:
 2. On whose behalf did it act?
 3. What authority did it have?
 4. Was the action allowed at the point of execution?
-5. What evidence proves what happened?
+5. What evidence supports review and reconstruction of the action path?
 
 AAEF treats these questions as the core of agentic action assurance.
 


### PR DESCRIPTION
## Summary

- Replaced remaining non-warning “evidence proves what happened” wording with review-and-reconstruction wording.
- Preserved intentional references that discuss “evidence proves what happened” as risky or avoided wording.
- Continued aligning public and status-document wording with AAEF's evidence non-proof boundary.

## Scope

This PR is a narrow documentation wording cleanup only.

It does not:

- update the active baseline
- update framework version
- create a new release
- create a v1.1.0 roadmap
- update `CITATION.cff`
- update `CHANGELOG.md`
- update validators
- update JSON fixture records
- update schemas
- update controls
- update assessment artifacts
- update testing procedures
- introduce scoped attestation freshness as a main AAEF concept
- add new evidence schema fields
- add validator behavior
- add executable code
- add live AI calls
- add external service calls
- add real RPA
- add real logistics processing
- add real shipment processing
- add real address changes
- add real backend execution
- add real credential use
- add real customer data
- add scanner behavior
- add vulnerability assessment behavior
- add exploit execution
- add destructive production operations
- add AAEF-AI-VA implementation details
- add patent-sensitive browser-state or diagnostic reconstruction detail
- add commercial PoC material
- open an active-baseline candidate review
- create a certification scheme
- create an audit opinion model
- claim legal sufficiency
- claim audit sufficiency
- claim compliance sufficiency
- claim evidence sufficiency
- claim assessment sufficiency
- claim production readiness
- claim implementation conformance
- claim control conformance
- claim external-framework equivalence

## Validation

- `py tools/validate_markdown_indexes.py`
- `py tools/validate_json_examples.py`
- `py tools/validate_evidence_schema.py`
- `py tools/validate_prototype_examples.py`

## Review note

The remaining grep matches for “evidence proves what happened” are expected only where the phrase is being described as risky or avoided wording.
